### PR TITLE
fix using zig fmt from zig v0.4.0

### DIFF
--- a/src/zigUtil.ts
+++ b/src/zigUtil.ts
@@ -121,29 +121,25 @@ export function execCmd
   }
 }
 
-export function findProj(dir: string): string {
+const buildFile = 'build.zig';
+
+export function findProj(dir: string, parent: string): string {
+  if (dir === '' || dir === parent) {
+    return '';
+  }
   if (fs.lstatSync(dir).isDirectory()) {
-    const files = fs.readdirSync(dir);
-    const file = files.find((v, i) => v === 'elm-package.json');
-    if (file !== undefined) {
-      return dir + path.sep + file;
-    }
-    let parent = '';
-    if (dir.lastIndexOf(path.sep) > 0) {
-      parent = dir.substr(0, dir.lastIndexOf(path.sep));
-    }
-    if (parent === '') {
-      return '';
-    } else {
-      return findProj(parent);
+    const build = path.join(dir, buildFile);
+    if (fs.existsSync(build)) {
+      return dir;
     }
   }
+  return findProj(path.dirname(dir), dir)
 }
 
 export function detectProjectRoot(fileName: string): string {
-  const proj = findProj(path.dirname(fileName));
+  const proj = findProj(path.dirname(fileName), '');
   if (proj !== '') {
-    return path.dirname(proj);
+    return proj;
   }
   return undefined;
 }


### PR DESCRIPTION
The code was checking  `elm-package.json` to signal the root of the root
of the project, for zig `build.zig file` is used instead.

Also this doesn't require to iterate over directories, uses simple
recursion instead.

I am using the latest zig version which ships with fmt command. When  `zig fmt` is run the binary will generate `zig-cache` so was running into weird errors because of the binary trying to create the cache on weird places. This fixes that issue because the command will properly use the `zig-cache` already on the project root or creating one in the correct location.