### PR TITLE
use output channels for zig fmt error messages

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -13,18 +13,19 @@ export function activate(context: vscode.ExtensionContext) {
     const zigFormatStatusBar = vscode.window.createStatusBarItem(
         vscode.StatusBarAlignment.Left,
     );
-
+    const logChannel = vscode.window.createOutputChannel('zig');
+    context.subscriptions.push(logChannel);
     context.subscriptions.push(
         vscode.languages.registerDocumentFormattingEditProvider(
             ZIG_MODE,
-            new ZigFormatProvider(zigFormatStatusBar),
+            new ZigFormatProvider(logChannel),
         ),
     );
 
     context.subscriptions.push(
         vscode.languages.registerDocumentRangeFormattingEditProvider(
             ZIG_MODE,
-            new ZigRangeFormatProvider(zigFormatStatusBar),
+            new ZigRangeFormatProvider(logChannel),
         ),
     );
 }

--- a/src/zigFormat.ts
+++ b/src/zigFormat.ts
@@ -28,7 +28,7 @@ export class ZigFormatProvider implements vscode.DocumentFormattingEditProvider 
                 return [TextEdit.replace(wholeDocument, stdout)];
             })
             .catch((reason) => {
-                logger.appendLine(`zig fmt failed. Check the file for syntax errors ${reason}`);
+                logger.appendLine(reason);
                 logger.show()
                 return null;
             });
@@ -62,7 +62,7 @@ export class ZigRangeFormatProvider implements vscode.DocumentRangeFormattingEdi
                 return [TextEdit.replace(wholeDocument, stdout)];
             })
             .catch((reason) => {
-                logger.appendLine(`zig fmt failed. Check the file for syntax errors ${reason}`);
+                logger.appendLine(reason);
                 logger.show()
                 return null;
             });


### PR DESCRIPTION

<img width="1680" alt="Screen Shot 2019-04-25 at 00 11 42" src="https://user-images.githubusercontent.com/6039952/56694464-62a97380-66ef-11e9-87e1-ba591cc0d791.png">
This shows additional information when zig fmt fails

There can be improvements but i think it can be done in a separate PR for instance replacing `<stdin>` with the file path which can allow the user to jump directly to the offending position.