### PR TITLE
Modifying .vscodeignore to the suggested settings.

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -1,3 +1,9 @@
-.vscode/**/*
+.vscode/**
+.vscode-test/**
+out/test/**
+src/**
 .gitignore
-out/
+**/tsconfig.json
+**/tslint.json
+**/*.map
+**/*.ts


### PR DESCRIPTION
Originally only wanted to remove 'out/' from the ignore list due to vsce not including it when running `vsce package`, but after seeing 

[https://github.com/Microsoft/vscode/issues/62687](https://github.com/Microsoft/vscode/issues/62687)

and 

[https://github.com/Microsoft/vscode-generator-code/blob/master/generators/app/templates/ext-command-ts/vscodeignore](https://github.com/Microsoft/vscode-generator-code/blob/master/generators/app/templates/ext-command-ts/vscodeignore)

it seemed reasonable to use the template .vscodeignore to cut down on unnecessary files in the final package.