### PR TITLE
add filename to the result of zig fmt failure

### DIFF
--- a/src/zigFormat.ts
+++ b/src/zigFormat.ts
@@ -29,7 +29,7 @@ export class ZigFormatProvider implements vscode.DocumentFormattingEditProvider 
             })
             .catch((reason) => {
                 logger.clear();
-                logger.appendLine(reason);
+                logger.appendLine(reason.toString().replace('<stdin>', document.fileName));
                 logger.show()
                 return null;
             });
@@ -64,7 +64,7 @@ export class ZigRangeFormatProvider implements vscode.DocumentRangeFormattingEdi
             })
             .catch((reason) => {
                 logger.clear();
-                logger.appendLine(reason);
+                logger.appendLine(reason.toString().replace('<stdin>', document.fileName));
                 logger.show()
                 return null;
             });


### PR DESCRIPTION
This replaces <stdtin> with actual filename allowing CTRL+click to go to
the offending  position.