### PR TITLE
Preserve editor focus when showing error from zig fmt

### DIFF
--- a/src/zigFormat.ts
+++ b/src/zigFormat.ts
@@ -30,7 +30,7 @@ export class ZigFormatProvider implements vscode.DocumentFormattingEditProvider 
             .catch((reason) => {
                 logger.clear();
                 logger.appendLine(reason.toString().replace('<stdin>', document.fileName));
-                logger.show()
+                logger.show(true)
                 return null;
             });
     }
@@ -65,7 +65,7 @@ export class ZigRangeFormatProvider implements vscode.DocumentRangeFormattingEdi
             .catch((reason) => {
                 logger.clear();
                 logger.appendLine(reason.toString().replace('<stdin>', document.fileName));
-                logger.show()
+                logger.show(true)
                 return null;
             });
     }


### PR DESCRIPTION
When `zig fmt` returns an error, the extension shows the error in a console window. When the console window appears, it previously stole focus from the editor. Since the extension runs `zig fmt` on save, this was very annoying, since focusing loses your position in the editor and requires you to click back.

This PR makes the extension pass `true` as the `preserveFocus: boolean` parameter to `OutputChannel.show`, which means that the output window doesn't steal focus and your cursor remains in the editor window to fix the typo.