### PR TITLE
improved regex for scraping compilation errors

### DIFF
--- a/src/zigCompilerProvider.ts
+++ b/src/zigCompilerProvider.ts
@@ -61,7 +61,7 @@ export default class ZigCompilerProvider implements vscode.CodeActionProvider {
             });
             childProcess.stdout.on('end', () => {
                 var diagnostics: { [id: string]: vscode.Diagnostic[]; } = {};
-                let regex = /(.*):(\d*):(\d*):([^:]*):(.*)/g;
+                let regex = /(\S.*):(\d*):(\d*): ([^:]*): (.*)/g;
 
                 this.diagnosticCollection.clear();
                 for (let match = regex.exec(decoded); match;


### PR DESCRIPTION
on windows the extension was was looking for nonexistent files because the regex introduced a stray space into paths.