### PR TITLE
Update pattern for unicode escape to \u{N...}

### DIFF
--- a/syntaxes/zig.tmLanguage.json
+++ b/syntaxes/zig.tmLanguage.json
@@ -139,7 +139,7 @@
       "patterns": [
         {
           "name": "constant.character.escape.zig",
-          "match": "\\\\([nrt'\"\\\\]|(x[0-9a-fA-F]{2})|(u[0-9a-fA-F]{4})|(U[0-9a-fA-F]{6}))"
+          "match": "\\\\([nrt'\"\\\\]|(x[0-9a-fA-F]{2})|(u\\{[0-9a-fA-F]+\\}))"
         },
         {
           "name": "invalid.illegal.unrecognized-string-escape.zig",


### PR DESCRIPTION
See https://github.com/ziglang/zig/issues/2129