### PR TITLE
Option to disable automatic raising of output window on formatting problems.

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "zig",
     "displayName": "Zig",
     "description": "Language support for the Zig programming language",
-    "version": "0.2.3",
+    "version": "0.2.2",
     "publisher": "tiehuis",
     "icon": "images/zig-icon.png",
     "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "zig",
     "displayName": "Zig",
     "description": "Language support for the Zig programming language",
-    "version": "0.2.2",
+    "version": "0.2.3",
     "publisher": "tiehuis",
     "icon": "images/zig-icon.png",
     "license": "MIT",
@@ -69,6 +69,11 @@
                     "type": "string",
                     "default": null,
                     "description": "Set a custom path to the Zig binary. Defaults to 'zig' in your PATH."
+                },
+                "zig.revealOutputChannelOnFormattingError": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Should output channel be reaised on formatting error."
                 }
             }
         }

--- a/src/zigFormat.ts
+++ b/src/zigFormat.ts
@@ -28,9 +28,13 @@ export class ZigFormatProvider implements vscode.DocumentFormattingEditProvider 
                 return [TextEdit.replace(wholeDocument, stdout), TextEdit.setEndOfLine(EndOfLine.LF)];
             })
             .catch((reason) => {
+                let config = vscode.workspace.getConfiguration('zig');
+
                 logger.clear();
                 logger.appendLine(reason.toString().replace('<stdin>', document.fileName));
-                logger.show(true)
+                if (config.get<boolean>("revealOutputChannelOnFormattingError")) {
+                    logger.show(true)
+                }
                 return null;
             });
     }
@@ -63,9 +67,13 @@ export class ZigRangeFormatProvider implements vscode.DocumentRangeFormattingEdi
                 return [TextEdit.replace(wholeDocument, stdout), TextEdit.setEndOfLine(EndOfLine.LF)];
             })
             .catch((reason) => {
+                const config = vscode.workspace.getConfiguration('zig');
+
                 logger.clear();
                 logger.appendLine(reason.toString().replace('<stdin>', document.fileName));
-                logger.show(true)
+                if (config.get<boolean>("revealOutputChannelOnFormattingError")) {
+                    logger.show(true)
+                }
                 return null;
             });
     }


### PR DESCRIPTION
Hello!

I usually got the errors from vscode's terminal window, so auto revealing output channel was quite annoying. 
This PR fixes this case for me and I hope did not break anything :) 