### PR TITLE
allow setting breakpoints in zig source files

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,11 @@
                 "path": "./syntaxes/zig.tmLanguage.json"
             }
         ],
+        "breakpoints": [
+            {
+                "language": "zig"
+            }
+        ],
         "configuration": {
             "type": "object",
             "title": "zig",


### PR DESCRIPTION
this is useful when debugging using the c++ extension