### PR TITLE
Fix multi-workspace diagnostics & build

### DIFF
--- a/src/zigBuild.ts
+++ b/src/zigBuild.ts
@@ -27,8 +27,7 @@ export function zigBuild(): void {
         processArg.push(element);
     });
 
-    // TODO: switch rootpath to support multi root
-    const cwd = vscode.workspace.rootPath;
+    const cwd = vscode.workspace.getWorkspaceFolder(editor.document.uri).uri.fsPath;
     const buildPath = config.get<string>("zigPath") || 'zig';
 
     logChannel.appendLine(`Starting building the current workspace at ${cwd}`);
@@ -63,3 +62,4 @@ export function zigBuild(): void {
         }
     });
 }
+


### PR DESCRIPTION
It wasn't showing errors when there were multiple folders at the root. Now it does.