### PR TITLE
Zig AstGen Diagnostics + more fixes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,14 +4,13 @@ on: [push, pull_request]
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v1
-    - name: build
-      run: |
-        npm install
-        tsc src/extension.ts
-        npx vsce package
-        ls -lt *.vsix
+      - uses: actions/checkout@v1
+      - name: build
+        run: |
+          npm install
+          npm run compile
+          npx vsce package
+          ls -lt *.vsix

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -7,3 +7,8 @@ src/**
 **/tslint.json
 **/*.map
 **/*.ts
+node_modules
+src
+*.lock
+package-lock.json
+tsconfig.json

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
         "url": "https://github.com/zig-lang/vscode-zig"
     },
     "engines": {
-        "vscode": "^1.43.0"
+        "vscode": "^1.56.0"
     },
     "categories": [
         "Programming Languages"
@@ -35,6 +35,21 @@
                 "language": "zig",
                 "scopeName": "source.zig",
                 "path": "./syntaxes/zig.tmLanguage.json"
+            }
+        ],
+        "problemMatchers": [
+            {
+                "name": "zig",
+                "owner": "zig",
+                "fileLocation": ["relative", "${workspaceFolder}"],
+                "pattern": {
+                    "regexp": "([^\\s]*):(\\d+):(\\d+):\\s+(?:fatal\\s+)?(note|error):\\s+(.*)$",
+                    "file": 1,
+                    "line": 2,
+                    "column": 3,
+                    "severity": 4,
+                    "message": 5
+                }
             }
         ],
         "configuration": {
@@ -98,9 +113,11 @@
     },
     "devDependencies": {
         "@types/mocha": "^2.2.48",
-        "@types/node": "^7.10.9",
+        "@types/node": "^15.6.0",
         "@types/vscode": "^1.43.0",
-        "typescript": "^2.9.2",
         "vscode-test": "^1.4.0"
+    },
+    "dependencies": {
+        "vsce": "^1.88.0"
     }
 }

--- a/package.json
+++ b/package.json
@@ -110,8 +110,8 @@
   },
   "scripts": {
     "vscode:prepublish": "npm run compile",
-    "compile": "esbuild --bundle --sourcemap=external --external:vscode src/extension.ts src/zigBuild.ts src/zigCompilerProvider.ts src/zigFormat.ts src/zigUtil.ts --outdir=out --platform=node --format=cjs",
-    "watch": "esbuild --watch --bundle --sourcemap=external --external:vscode src/extension.ts src/zigBuild.ts src/zigCompilerProvider.ts src/zigFormat.ts src/zigUtil.ts --outdir=out --platform=node --format=cjs",
+    "compile": "esbuild --bundle --sourcemap=external --minify --external:vscode src/extension.ts --outdir=out --platform=node --format=cjs",
+    "watch": "esbuild --watch --bundle --sourcemap=external --external:vscode src/extension.ts --outdir=out --platform=node --format=cjs",
     "test": "npm run compile && node ./node_modules/vscode/bin/test"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,123 +1,129 @@
 {
-    "name": "zig",
-    "displayName": "Zig",
-    "description": "Language support for the Zig programming language",
-    "version": "0.2.5",
-    "publisher": "tiehuis",
-    "icon": "images/zig-icon.png",
-    "license": "MIT",
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/zig-lang/vscode-zig"
-    },
-    "engines": {
-        "vscode": "^1.56.0"
-    },
-    "categories": [
-        "Programming Languages"
+  "name": "zig",
+  "displayName": "Zig",
+  "description": "Language support for the Zig programming language",
+  "version": "0.2.5",
+  "publisher": "tiehuis",
+  "icon": "images/zig-icon.png",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/zig-lang/vscode-zig"
+  },
+  "engines": {
+    "vscode": "^1.56.0"
+  },
+  "categories": [
+    "Programming Languages"
+  ],
+  "activationEvents": [
+    "onLanguage:zig"
+  ],
+  "main": "./out/extension",
+  "contributes": {
+    "languages": [
+      {
+        "id": "zig",
+        "extensions": [
+          ".zig"
+        ],
+        "configuration": "./language-configuration.json"
+      }
     ],
-    "activationEvents": [
-        "onLanguage:zig"
+    "grammars": [
+      {
+        "language": "zig",
+        "scopeName": "source.zig",
+        "path": "./syntaxes/zig.tmLanguage.json"
+      }
     ],
-    "main": "./out/extension",
-    "contributes": {
-        "languages": [
-            {
-                "id": "zig",
-                "extensions": [
-                    ".zig"
-                ],
-                "configuration": "./language-configuration.json"
-            }
+    "problemMatchers": [
+      {
+        "name": "zig",
+        "owner": "zig",
+        "fileLocation": [
+          "relative",
+          "${workspaceFolder}"
         ],
-        "grammars": [
-            {
-                "language": "zig",
-                "scopeName": "source.zig",
-                "path": "./syntaxes/zig.tmLanguage.json"
-            }
-        ],
-        "problemMatchers": [
-            {
-                "name": "zig",
-                "owner": "zig",
-                "fileLocation": ["relative", "${workspaceFolder}"],
-                "pattern": {
-                    "regexp": "([^\\s]*):(\\d+):(\\d+):\\s+(?:fatal\\s+)?(note|error):\\s+(.*)$",
-                    "file": 1,
-                    "line": 2,
-                    "column": 3,
-                    "severity": 4,
-                    "message": 5
-                }
-            }
-        ],
-        "configuration": {
-            "type": "object",
-            "title": "zig",
-            "properties": {
-                "zig.buildOnSave": {
-                    "type": "boolean",
-                    "default": false,
-                    "description": "Compiles code on file save using the settings specified in 'Build Option'."
-                },
-                "zig.buildOption": {
-                    "type": "string",
-                    "default": "build",
-                    "enum": [
-                        "build",
-                        "build-exe",
-                        "build-lib",
-                        "build-obj"
-                    ],
-                    "description": "Which build command Zig should use to build the code."
-                },
-                "zig.buildArgs": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    },
-                    "default": [],
-                    "description": "Extra arguments to passed to Zig."
-                },
-                "zig.buildFilePath": {
-                    "type": "string",
-                    "default": "${workspaceFolder}/build.zig",
-                    "description": "The path to build.zig. This is only required if zig.buildOptions = build."
-                },
-                "zig.zigPath": {
-                    "type": "string",
-                    "default": null,
-                    "description": "Set a custom path to the Zig binary. Defaults to 'zig' in your PATH."
-                },
-                "zig.revealOutputChannelOnFormattingError": {
-                    "type": "boolean",
-                    "default": true,
-                    "description": "Should output channel be raised on formatting error."
-                }
-            }
+        "pattern": {
+          "regexp": "([^\\s]*):(\\d+):(\\d+):\\s+(?:fatal\\s+)?(note|error):\\s+(.*)$",
+          "file": 1,
+          "line": 2,
+          "column": 3,
+          "severity": 4,
+          "message": 5
+        }
+      }
+    ],
+    "configuration": {
+      "type": "object",
+      "title": "zig",
+      "properties": {
+        "zig.buildOnSave": {
+          "type": "boolean",
+          "default": false,
+          "description": "Compiles code on file save using the settings specified in 'Build Option'."
         },
-        "commands": [
-            {
-                "command": "zig.build.workspace",
-                "title": "Zig: Build Workspace",
-                "description": "Build the current project using 'zig build'"
-            }
-        ]
+        "zig.buildOption": {
+          "type": "string",
+          "default": "build",
+          "enum": [
+            "build",
+            "build-exe",
+            "build-lib",
+            "build-obj"
+          ],
+          "description": "Which build command Zig should use to build the code."
+        },
+        "zig.buildArgs": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": [],
+          "description": "Extra arguments to passed to Zig."
+        },
+        "zig.buildFilePath": {
+          "type": "string",
+          "default": "${workspaceFolder}/build.zig",
+          "description": "The path to build.zig. This is only required if zig.buildOptions = build."
+        },
+        "zig.zigPath": {
+          "type": "string",
+          "default": null,
+          "description": "Set a custom path to the Zig binary. Defaults to 'zig' in your PATH."
+        },
+        "zig.revealOutputChannelOnFormattingError": {
+          "type": "boolean",
+          "default": true,
+          "description": "Should output channel be raised on formatting error."
+        }
+      }
     },
-    "scripts": {
-        "vscode:prepublish": "npm run compile",
-        "compile": "tsc -p ./",
-        "watch": "tsc -watch -p ./",
-        "test": "npm run compile && node ./node_modules/vscode/bin/test"
-    },
-    "devDependencies": {
-        "@types/mocha": "^2.2.48",
-        "@types/node": "^15.6.0",
-        "@types/vscode": "^1.43.0",
-        "vscode-test": "^1.4.0"
-    },
-    "dependencies": {
-        "vsce": "^1.88.0"
-    }
+    "commands": [
+      {
+        "command": "zig.build.workspace",
+        "title": "Zig: Build Workspace",
+        "description": "Build the current project using 'zig build'"
+      }
+    ]
+  },
+  "scripts": {
+    "vscode:prepublish": "npm run compile",
+    "compile": "esbuild --bundle --sourcemap=external --external:vscode src/extension.ts src/zigBuild.ts src/zigCompilerProvider.ts src/zigFormat.ts src/zigUtil.ts --outdir=out --platform=node --format=cjs",
+    "watch": "esbuild --watch --bundle --sourcemap=external --external:vscode src/extension.ts src/zigBuild.ts src/zigCompilerProvider.ts src/zigFormat.ts src/zigUtil.ts --outdir=out --platform=node --format=cjs",
+    "test": "npm run compile && node ./node_modules/vscode/bin/test"
+  },
+  "devDependencies": {
+    "@types/mocha": "^2.2.48",
+    "@types/node": "^15.6.0",
+    "@types/vscode": "^1.43.0",
+    "vscode-test": "^1.4.0"
+  },
+  "dependencies": {
+    "esbuild": "^0.12.1",
+    "lodash-es": "^4.17.21",
+    "lodash.debounce": "^4.0.8",
+    "vsce": "^1.88.0"
+  }
 }

--- a/src/zigBuild.ts
+++ b/src/zigBuild.ts
@@ -41,6 +41,13 @@ export function zigBuild(): void {
         for (let match = regex.exec(stderr); match;
             match = regex.exec(stderr)) {
             let path = match[1].trim();
+            try {
+                if (!path.includes(cwd)) {
+                    path = require("path").resolve(cwd, path);
+                }
+            } catch {
+
+            }
             let line = parseInt(match[2]) - 1;
             let column = parseInt(match[3]) - 1;
             let type = match[4];
@@ -50,7 +57,7 @@ export function zigBuild(): void {
                 vscode.DiagnosticSeverity.Error :
                 vscode.DiagnosticSeverity.Information;
 
-            let range = new vscode.Range(line, column, line, column + 1);
+            let range = new vscode.Range(line, column, line, Infinity);
 
             if (diagnostics[path] == null) diagnostics[path] = [];
             diagnostics[path].push(new vscode.Diagnostic(range, message, severity));

--- a/src/zigCompilerProvider.ts
+++ b/src/zigCompilerProvider.ts
@@ -72,11 +72,7 @@ export default class ZigCompilerProvider implements vscode.CodeActionProvider {
     const cwd = vscode.workspace.getWorkspaceFolder(textDocument.uri).uri
       .fsPath;
 
-    let childProcess = cp.spawn(
-      zig_path as string,
-      ["astgen", "--errors-only", "--stdin"],
-      { cwd }
-    );
+    let childProcess = cp.spawn(zig_path as string, ["ast-check"], { cwd });
 
     if (!childProcess.pid) {
       return;

--- a/src/zigCompilerProvider.ts
+++ b/src/zigCompilerProvider.ts
@@ -1,111 +1,230 @@
-'use strict';
+"use strict";
 
-import * as path from 'path';
-import * as cp from 'child_process';
-import * as vscode from 'vscode';
+import * as path from "path";
+import * as cp from "child_process";
+import * as vscode from "vscode";
+// This will be treeshaked to only the debounce function
+import { throttle } from "lodash-es";
 
 export default class ZigCompilerProvider implements vscode.CodeActionProvider {
-    private diagnosticCollection: vscode.DiagnosticCollection;
+  private buildDiagnostics: vscode.DiagnosticCollection;
+  private astDiagnostics: vscode.DiagnosticCollection;
+  private dirtyChange = new WeakMap<vscode.Uri, boolean>();
 
-    public activate(subscriptions: vscode.Disposable[]) {
-        subscriptions.push(this);
-        this.diagnosticCollection = vscode.languages.createDiagnosticCollection("zig");
+  public activate(subscriptions: vscode.Disposable[]) {
+    subscriptions.push(this);
+    this.buildDiagnostics = vscode.languages.createDiagnosticCollection("zig");
+    this.astDiagnostics = vscode.languages.createDiagnosticCollection("zig");
 
-        vscode.workspace.onDidOpenTextDocument(this.doCompile, this, subscriptions);
-        vscode.workspace.onDidCloseTextDocument((textDocument) => {
-            this.diagnosticCollection.delete(textDocument.uri);
-        }, null, subscriptions);
+    // vscode.workspace.onDidOpenTextDocument(this.doCompile, this, subscriptions);
+    // vscode.workspace.onDidCloseTextDocument(
+    //   (textDocument) => {
+    //     this.diagnosticCollection.delete(textDocument.uri);
+    //   },
+    //   null,
+    //   subscriptions
+    // );
 
-        vscode.workspace.onDidSaveTextDocument(this.doCompile, this);
+    // vscode.workspace.onDidSaveTextDocument(this.doCompile, this);
+    vscode.workspace.onDidChangeTextDocument(
+      this.maybeDoASTGenErrorCheck,
+      this
+    );
+  }
+
+  maybeDoASTGenErrorCheck(change: vscode.TextDocumentChangeEvent) {
+    if (change.document.languageId !== "zig") return;
+    if (change.document.isClosed) {
+      this.astDiagnostics.delete(change.document.uri);
     }
 
-    public dispose(): void {
-        this.diagnosticCollection.clear();
-        this.diagnosticCollection.dispose();
+    this.doASTGenErrorCheck(change);
+
+    if (!change.document.isUntitled) {
+      let config = vscode.workspace.getConfiguration("zig");
+      if (
+        config.get<boolean>("buildOnSave") &&
+        this.dirtyChange.has(change.document.uri) &&
+        this.dirtyChange.get(change.document.uri) !== change.document.isDirty &&
+        !change.document.isDirty
+      ) {
+        this.doCompile(change.document);
+      }
+
+      this.dirtyChange.set(change.document.uri, change.document.isDirty);
+    }
+  }
+
+  public dispose(): void {
+    this.buildDiagnostics.clear();
+    this.astDiagnostics.clear();
+    this.buildDiagnostics.dispose();
+    this.astDiagnostics.dispose();
+  }
+
+  private _doASTGenErrorCheck(change: vscode.TextDocumentChangeEvent) {
+    let config = vscode.workspace.getConfiguration("zig");
+    const textDocument = change.document;
+    if (textDocument.languageId !== "zig") {
+      return;
+    }
+    const zig_path = config.get("zigPath") || "zig";
+    const cwd = vscode.workspace.getWorkspaceFolder(textDocument.uri).uri
+      .fsPath;
+
+    let childProcess = cp.spawn(
+      zig_path as string,
+      ["astgen", "--errors-only", "--stdin"],
+      { cwd }
+    );
+
+    if (!childProcess.pid) {
+      return;
     }
 
-    private doCompile(textDocument: vscode.TextDocument) {
-        let config = vscode.workspace.getConfiguration('zig');
-        let buildOnSave = config.get<boolean>("buildOnSave");
+    var stderr = "";
+    childProcess.stderr.on("data", (chunk) => {
+      stderr += chunk;
+    });
 
-        if (textDocument.languageId !== 'zig' || !buildOnSave) {
-            return;
-        }
+    childProcess.stdin.end(change.document.getText(null));
 
-        let buildOption = config.get<string>("buildOption");
-        let processArg: string[] = [buildOption];
-        let workspaceFolder = vscode.workspace.getWorkspaceFolder(textDocument.uri);
-        if (!workspaceFolder && vscode.workspace.workspaceFolders.length) {
-            workspaceFolder = vscode.workspace.workspaceFolders[0];
-        }
-        const cwd = workspaceFolder.uri.fsPath;
+    childProcess.once("close", () => {
+      this.doASTGenErrorCheck.cancel();
+      this.astDiagnostics.delete(textDocument.uri);
 
-        switch (buildOption) {
-            case "build":
-                let buildFilePath = config.get<string>("buildFilePath");
-                processArg.push("--build-file");
-                try {
-                    processArg.push(    path.resolve(buildFilePath.replace("${workspaceFolder}", cwd)));
-                } catch {
+      if (stderr.length == 0) return;
+      var diagnostics: { [id: string]: vscode.Diagnostic[] } = {};
+      let regex = /(\S.*):(\d*):(\d*): ([^:]*): (.*)/g;
 
-                }
-                
-                break;
-            default:
-                processArg.push(textDocument.fileName);
-                break;
-        }
-        
+      for (let match = regex.exec(stderr); match; match = regex.exec(stderr)) {
+        let path = textDocument.uri.fsPath;
 
-        let extraArgs = config.get<string[]>("buildArgs");
-        extraArgs.forEach(element => {
-            processArg.push(element);
-        });
+        let line = parseInt(match[2]) - 1;
+        let column = parseInt(match[3]) - 1;
+        let type = match[4];
+        let message = match[5];
 
-        let decoded = ''
-        let childProcess = cp.spawn('zig', processArg, {cwd});
-        if (childProcess.pid) {
-            childProcess.stderr.on('data', (data: Buffer) => {
-                decoded += data;
-            });
-            childProcess.stdout.on('end', () => {
-                var diagnostics: { [id: string]: vscode.Diagnostic[]; } = {};
-                let regex = /(\S.*):(\d*):(\d*): ([^:]*): (.*)/g;
+        let severity =
+          type.trim().toLowerCase() === "error"
+            ? vscode.DiagnosticSeverity.Error
+            : vscode.DiagnosticSeverity.Information;
+        let range = new vscode.Range(line, column, line, Infinity);
 
-                this.diagnosticCollection.clear();
-                for (let match = regex.exec(decoded); match;
-                    match = regex.exec(decoded)) {
-                    let path = match[1].trim();
-                    try {
-                        if (!path.includes(cwd)) {
-                            path = require("path").resolve(workspaceFolder.uri.fsPath, path);
-                        }
-                    } catch {
+        if (diagnostics[path] == null) diagnostics[path] = [];
+        diagnostics[path].push(new vscode.Diagnostic(range, message, severity));
+      }
 
-                    }
+      for (let path in diagnostics) {
+        let diagnostic = diagnostics[path];
+        this.astDiagnostics.set(textDocument.uri, diagnostic);
+      }
+    });
+  }
 
-                    let line = parseInt(match[2]) - 1;
-                    let column = parseInt(match[3]) - 1;
-                    let type = match[4];
-                    let message = match[5];
+  private _doCompile(textDocument: vscode.TextDocument) {
+    let config = vscode.workspace.getConfiguration("zig");
 
-                    let severity = type.trim().toLowerCase() === "error" ? vscode.DiagnosticSeverity.Error : vscode.DiagnosticSeverity.Information;
-                    let range = new vscode.Range(line, column,
-                        line, Infinity);
+    let buildOption = config.get<string>("buildOption");
+    let processArg: string[] = [buildOption];
+    let workspaceFolder = vscode.workspace.getWorkspaceFolder(textDocument.uri);
+    if (!workspaceFolder && vscode.workspace.workspaceFolders.length) {
+      workspaceFolder = vscode.workspace.workspaceFolders[0];
+    }
+    const cwd = workspaceFolder.uri.fsPath;
 
-                    if (diagnostics[path] == null) diagnostics[path] = [];
-                    diagnostics[path].push(new vscode.Diagnostic(range, message, severity));
-                }
+    switch (buildOption) {
+      case "build":
+        let buildFilePath = config.get<string>("buildFilePath");
+        processArg.push("--build-file");
+        try {
+          processArg.push(
+            path.resolve(buildFilePath.replace("${workspaceFolder}", cwd))
+          );
+        } catch {}
 
-                for (let path in diagnostics) {
-                    let diagnostic = diagnostics[path];
-                    this.diagnosticCollection.set(vscode.Uri.file(path), diagnostic);
-                }
-            });
-        }
+        break;
+      default:
+        processArg.push(textDocument.fileName);
+        break;
     }
 
-    public provideCodeActions(document: vscode.TextDocument, range: vscode.Range, context: vscode.CodeActionContext, token: vscode.CancellationToken): vscode.ProviderResult<vscode.Command[]> {
-        return [];
+    let extraArgs = config.get<string[]>("buildArgs");
+    extraArgs.forEach((element) => {
+      processArg.push(element);
+    });
+
+    let decoded = "";
+    let childProcess = cp.spawn("zig", processArg, { cwd });
+    if (childProcess.pid) {
+      childProcess.stderr.on("data", (data: Buffer) => {
+        decoded += data;
+      });
+      childProcess.stdout.on("end", () => {
+        this.doCompile.cancel();
+        var diagnostics: { [id: string]: vscode.Diagnostic[] } = {};
+        let regex = /(\S.*):(\d*):(\d*): ([^:]*): (.*)/g;
+
+        this.buildDiagnostics.clear();
+        for (
+          let match = regex.exec(decoded);
+          match;
+          match = regex.exec(decoded)
+        ) {
+          let path = match[1].trim();
+          try {
+            if (!path.includes(cwd)) {
+              path = require("path").resolve(workspaceFolder.uri.fsPath, path);
+            }
+          } catch {}
+
+          let line = parseInt(match[2]) - 1;
+          let column = parseInt(match[3]) - 1;
+          let type = match[4];
+          let message = match[5];
+
+          // De-dupe build errors with ast errors
+          if (this.astDiagnostics.has(textDocument.uri)) {
+            for (let diag of this.astDiagnostics.get(textDocument.uri)) {
+              if (
+                diag.range.start.line === line &&
+                diag.range.start.character === column
+              ) {
+                continue;
+              }
+            }
+          }
+
+          let severity =
+            type.trim().toLowerCase() === "error"
+              ? vscode.DiagnosticSeverity.Error
+              : vscode.DiagnosticSeverity.Information;
+          let range = new vscode.Range(line, column, line, Infinity);
+
+          if (diagnostics[path] == null) diagnostics[path] = [];
+          diagnostics[path].push(
+            new vscode.Diagnostic(range, message, severity)
+          );
+        }
+
+        for (let path in diagnostics) {
+          let diagnostic = diagnostics[path];
+          this.buildDiagnostics.set(vscode.Uri.file(path), diagnostic);
+        }
+      });
     }
+  }
+
+  doASTGenErrorCheck = throttle(this._doASTGenErrorCheck, 16, {
+    trailing: true,
+  });
+  doCompile = throttle(this._doCompile, 60);
+  public provideCodeActions(
+    document: vscode.TextDocument,
+    range: vscode.Range,
+    context: vscode.CodeActionContext,
+    token: vscode.CancellationToken
+  ): vscode.ProviderResult<vscode.Command[]> {
+    return [];
+  }
 }

--- a/src/zigFormat.ts
+++ b/src/zigFormat.ts
@@ -25,7 +25,7 @@ export class ZigFormatProvider implements vscode.DocumentFormattingEditProvider 
                     lastLineId,
                     document.lineAt(lastLineId).text.length,
                 );
-                return [TextEdit.replace(wholeDocument, stdout), TextEdit.setEndOfLine(EndOfLine.LF)];
+                return [new TextEdit(wholeDocument, stdout),];
             })
             .catch((reason) => {
                 let config = vscode.workspace.getConfiguration('zig');
@@ -64,7 +64,7 @@ export class ZigRangeFormatProvider implements vscode.DocumentRangeFormattingEdi
                     lastLineId,
                     document.lineAt(lastLineId).text.length,
                 );
-                return [TextEdit.replace(wholeDocument, stdout), TextEdit.setEndOfLine(EndOfLine.LF)];
+                return [new TextEdit(wholeDocument, stdout),];
             })
             .catch((reason) => {
                 const config = vscode.workspace.getConfiguration('zig');

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,10 +1,10 @@
 {
     "compilerOptions": {
         "module": "commonjs",
-        "target": "es6",
+        "target": "ESNext",
         "outDir": "out",
         "lib": [
-            "es6"
+            "esnext",
         ],
         "sourceMap": true,
         "rootDir": "src"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,16 +1,12 @@
 {
-    "compilerOptions": {
-        "module": "commonjs",
-        "target": "ESNext",
-        "outDir": "out",
-        "lib": [
-            "esnext",
-        ],
-        "sourceMap": true,
-        "rootDir": "src"
-    },
-    "exclude": [
-        "node_modules",
-        ".vscode-test"
-    ]
+  "compilerOptions": {
+    "module": "commonjs",
+    "target": "ESNext",
+    "outDir": "out",
+    "esModuleInterop": true,
+    "lib": ["esnext"],
+    "sourceMap": true,
+    "rootDir": "src"
+  },
+  "exclude": ["node_modules", ".vscode-test"]
 }


### PR DESCRIPTION
Add support for instant diagnostics via `zig astgen`

https://user-images.githubusercontent.com/709451/119241831-44044980-bb0e-11eb-918d-cdb6b9a17932.mov

Plus:
- Fix cursor jumping to end of file on zig fmt in large files
- Fix diagnostics for build on save
- Fix diagnostics for zig build
- Makes diagnostic tokens wrap to end of nearest word instead of single character. It makes it much clearer where errors are located (that's VSCode's behavior when you pass `Infinity` to a column range)

This also:
- Bumps to latest typescript version
- Makes tsconfig.json emit modern JS instead of JS from 2016. VSCode extensions don't need to support Internet Explorer 11 :)
- Bumps to latest VSCode engine version. This is necessary for diagnostics to work.
- Switches to esbuild because `tsc` doesn't seem to support importing modules inside of commonjs (it needs to bundle them), which is used for throttling the frequency of updates to max of `16ms` for `zig astgen` and `60ms` for zig build
- Run `prettier` on modified files (`zig fmt` but for JavaScript)