### PR TITLE
Add run test button

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,11 +23,11 @@
   "contributes": {
     "taskDefinitions": [
       {
-        "type": "zig",
+        "type": "zig test",
         "properties": {
           "filter": {
             "type": "string",
-            "description": "Test name to only run"
+            "description": "Test name to filter against"
           },
           "args": {
             "type": "string",
@@ -35,7 +35,7 @@
           },
           "file": {
             "type": "string",
-            "description": "The Rake file that provides the task. Can be omitted."
+            "description": "The file path to the zig source code to filter the test. Can be omitted."
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -21,6 +21,25 @@
   ],
   "main": "./out/extension",
   "contributes": {
+    "taskDefinitions": [
+      {
+        "type": "zig",
+        "properties": {
+          "filter": {
+            "type": "string",
+            "description": "Test name to only run"
+          },
+          "args": {
+            "type": "string",
+            "description": "Additional args to pass \"zig test\""
+          },
+          "file": {
+            "type": "string",
+            "description": "The Rake file that provides the task. Can be omitted."
+          }
+        }
+      }
+    ],
     "languages": [
       {
         "id": "zig",
@@ -92,6 +111,16 @@
           "type": "string",
           "default": null,
           "description": "Set a custom path to the Zig binary. Defaults to 'zig' in your PATH."
+        },
+        "zig.testArgs": {
+          "type": "string",
+          "default": "",
+          "description": "Additional flags to pass \"zig test\""
+        },
+        "zig.disableProblemMatcherForTest": {
+          "type": "bool",
+          "default": false,
+          "description": "Highlight lines where tests failed"
         },
         "zig.revealOutputChannelOnFormattingError": {
           "type": "boolean",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -76,11 +76,15 @@ export function activate(context: vscode.ExtensionContext) {
     const bin = (config.get("zigPath") as string) || "zig";
 
     const testOptions = (task.definition.args as string) || "";
-
+    var main_package_path = "";
+    try {
+      main_package_path = path.resolve(workspaceFolder.uri.fsPath, "build.zig");
+    } catch {}
     const args = [
       bin,
       "test",
-
+      main_package_path.length &&
+        `--main-pkg-path ${workspaceFolder.uri.fsPath}`,
       filename && path.relative(workspaceFolder.uri.fsPath, filename.fsPath),
       filter && filter.length > 0 && `--test-filter ${filter}`,
       testOptions,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,42 +1,134 @@
-'use strict';
-import * as vscode from 'vscode';
-import ZigCompilerProvider from './zigCompilerProvider';
-import { zigBuild } from './zigBuild';
-import { ZigFormatProvider, ZigRangeFormatProvider } from './zigFormat';
-
-const ZIG_MODE: vscode.DocumentFilter = { language: 'zig', scheme: 'file' };
+"use strict";
+import * as vscode from "vscode";
+import ZigCompilerProvider from "./zigCompilerProvider";
+import { zigBuild } from "./zigBuild";
+import { ZigFormatProvider, ZigRangeFormatProvider } from "./zigFormat";
+import * as child_process from "child_process";
+import { CodelensProvider } from "./zigCodeLensProvider";
+import path from "path";
+const ZIG_MODE: vscode.DocumentFilter = { language: "zig", scheme: "file" };
 
 export let buildDiagnosticCollection: vscode.DiagnosticCollection;
-export const logChannel = vscode.window.createOutputChannel('zig');
-export const zigFormatStatusBar = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left);
+export const logChannel = vscode.window.createOutputChannel("zig");
+export let terminal: vscode.Terminal;
+export const zigFormatStatusBar = vscode.window.createStatusBarItem(
+  vscode.StatusBarAlignment.Left
+);
 
 export function activate(context: vscode.ExtensionContext) {
-    let compiler = new ZigCompilerProvider();
-    compiler.activate(context.subscriptions);
-    vscode.languages.registerCodeActionsProvider('zig', compiler);
+  let compiler = new ZigCompilerProvider();
+  let codeLens = new CodelensProvider();
+  compiler.activate(context.subscriptions);
 
-    context.subscriptions.push(logChannel);
-    context.subscriptions.push(
-        vscode.languages.registerDocumentFormattingEditProvider(
-            ZIG_MODE,
-            new ZigFormatProvider(logChannel),
-        ),
-    );
+  context.subscriptions.push(
+    vscode.languages.registerCodeActionsProvider("zig", compiler)
+  );
+  context.subscriptions.push(
+    vscode.languages.registerCodeLensProvider("zig", codeLens)
+  );
 
-    context.subscriptions.push(
-        vscode.languages.registerDocumentRangeFormattingEditProvider(
-            ZIG_MODE,
-            new ZigRangeFormatProvider(logChannel),
-        ),
-    );
+  context.subscriptions.push(logChannel);
+  context.subscriptions.push(
+    vscode.languages.registerDocumentFormattingEditProvider(
+      ZIG_MODE,
+      new ZigFormatProvider(logChannel)
+    )
+  );
 
-    buildDiagnosticCollection = vscode.languages.createDiagnosticCollection('zig');
-    context.subscriptions.push(buildDiagnosticCollection);
+  context.subscriptions.push(
+    vscode.languages.registerDocumentRangeFormattingEditProvider(
+      ZIG_MODE,
+      new ZigRangeFormatProvider(logChannel)
+    )
+  );
 
-    // Commands
-    context.subscriptions.push(vscode.commands.registerCommand('zig.build.workspace', () => zigBuild()));
-    context.subscriptions.push(vscode.commands.registerCommand('zig.format.file', () => console.log('test')));
+  buildDiagnosticCollection =
+    vscode.languages.createDiagnosticCollection("zig");
+  context.subscriptions.push(buildDiagnosticCollection);
+
+  // Commands
+  context.subscriptions.push(
+    vscode.commands.registerCommand("zig.build.workspace", () => zigBuild())
+  );
+  context.subscriptions.push(
+    vscode.commands.registerCommand("zig.format.file", () =>
+      console.log("test")
+    )
+  );
+
+  const resolveTask = function resolveTask(task: vscode.Task, token) {
+    if (!task.presentationOptions) {
+      task.presentationOptions = {};
+    }
+
+    task.presentationOptions.clear = true;
+    task.presentationOptions.reveal = vscode.TaskRevealKind.Always;
+    task.presentationOptions.showReuseMessage = false;
+
+    const workspaceFolder = task.scope as vscode.WorkspaceFolder;
+    const filename = task.definition.file as vscode.Uri;
+    const filter = task.definition.filter as string;
+    const config = vscode.workspace.getConfiguration("zig");
+    const bin = (config.get("zigPath") as string) || "zig";
+
+    const testOptions = (task.definition.args as string) || "";
+
+    const args = [
+      bin,
+      "test",
+
+      filename && path.relative(workspaceFolder.uri.fsPath, filename.fsPath),
+      filter && filter.length > 0 && `--test-filter ${filter}`,
+      testOptions,
+    ].filter((a) => Boolean(a));
+
+    task.problemMatchers = !config.get("disableProblemMatcherForTest")
+      ? ["zig"]
+      : [];
+    task.execution = new vscode.ShellExecution(args.join(" "), {});
+
+    return task;
+  };
+
+  context.subscriptions.push(
+    vscode.tasks.registerTaskProvider("zig", {
+      provideTasks: (token) => {
+        return [
+          new vscode.Task(
+            { type: "zig", task: "zig test" },
+            vscode.workspace.workspaceFolders[0],
+            "zig test",
+            "zig",
+            new vscode.ShellExecution("zig test")
+          ),
+        ];
+      },
+      resolveTask,
+    })
+  );
+
+  context.subscriptions.push(
+    vscode.commands.registerCommand(
+      "zig.test.run",
+      (filename: vscode.Uri, filter: string) => {
+        const task = new vscode.Task(
+          { type: "zig", task: "test" },
+          vscode.workspace.workspaceFolders[0],
+          "zig test",
+          "zig",
+          new vscode.ShellExecution("zig test")
+        );
+        task.detail = "zig test";
+
+        const config = vscode.workspace.getConfiguration("zig");
+
+        task.definition.file = filename;
+        task.definition.filter = filter;
+        task.definition.args = config.get("testArgs") || "";
+        vscode.tasks.executeTask(resolveTask(task, null));
+      }
+    )
+  );
 }
 
-export function deactivate() {
-}
+export function deactivate() {}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -20,11 +20,15 @@ export function activate(context: vscode.ExtensionContext) {
   let codeLens = new CodelensProvider();
   compiler.activate(context.subscriptions);
 
+  const select: vscode.DocumentSelector = {
+    language: "zig",
+    scheme: "file",
+  };
   context.subscriptions.push(
-    vscode.languages.registerCodeActionsProvider("zig", compiler)
+    vscode.languages.registerCodeActionsProvider(select, compiler)
   );
   context.subscriptions.push(
-    vscode.languages.registerCodeLensProvider("zig", codeLens)
+    vscode.languages.registerCodeLensProvider(select, codeLens)
   );
 
   context.subscriptions.push(logChannel);
@@ -95,7 +99,7 @@ export function activate(context: vscode.ExtensionContext) {
       provideTasks: (token) => {
         return [
           new vscode.Task(
-            { type: "zig", task: "zig test" },
+            { type: "zig test", task: "zig test" },
             vscode.workspace.workspaceFolders[0],
             "zig test",
             "zig",
@@ -112,7 +116,7 @@ export function activate(context: vscode.ExtensionContext) {
       "zig.test.run",
       (filename: vscode.Uri, filter: string) => {
         const task = new vscode.Task(
-          { type: "zig", task: "test" },
+          { type: "zig test", task: "test" },
           vscode.workspace.workspaceFolders[0],
           "zig test",
           "zig",

--- a/src/zigCodeLensProvider.ts
+++ b/src/zigCodeLensProvider.ts
@@ -20,105 +20,99 @@ export class CodelensProvider implements vscode.CodeLensProvider {
     document: vscode.TextDocument,
     token: vscode.CancellationToken
   ): vscode.CodeLens[] | Thenable<vscode.CodeLens[]> {
-    if (
-      vscode.workspace
-        .getConfiguration("codelens-sample")
-        .get("enableCodeLens", true)
-    ) {
-      this.codeLenses = [];
-      const text = document.getText();
-      let matches;
+    this.codeLenses = [];
+    const text = document.getText();
 
-      var was_newline = false;
-      var test_keyword_start = -1;
-      for (let i = 0; i < text.length; i++) {
-        // test "foo"
-        // ^
-        if (
-          was_newline &&
-          text.length > i + 4 &&
-          text[i] === "t" &&
-          text[i + 1] === "e" &&
-          text[i + 2] === "s" &&
-          text[i + 3] === "t" &&
-          (text[i + 4] === " " || text[i + 4] === "\n")
-        ) {
-          test_keyword_start = i;
-          i += 4;
-        }
+    var was_newline = false;
+    var test_keyword_start = -1;
+    for (let i = 0; i < text.length; i++) {
+      // test "foo"
+      // ^
+      if (
+        was_newline &&
+        text.length > i + 4 &&
+        text[i] === "t" &&
+        text[i + 1] === "e" &&
+        text[i + 2] === "s" &&
+        text[i + 3] === "t" &&
+        (text[i + 4] === " " || text[i + 4] === "\n")
+      ) {
+        test_keyword_start = i;
+        i += 4;
+      }
 
-        // test "foo"
-        //      ^
-        if (test_keyword_start > -1 && text[i] === '"') {
-          i += 1;
-          const quote_start = i;
+      // test "foo"
+      //      ^
+      if (test_keyword_start > -1 && text[i] === '"') {
+        i += 1;
+        const quote_start = i;
 
-          while (i < text.length && text[i] !== '"') {
-            if (text[i] === "\\" && text[i + 1] === '"') {
-              i += 1;
-            }
+        while (i < text.length && text[i] !== '"') {
+          if (text[i] === "\\" && text[i + 1] === '"') {
             i += 1;
           }
-          const quote_end = i;
+          i += 1;
+        }
+        const quote_end = i;
 
-          const line = document.lineAt(
-            document.positionAt(test_keyword_start).line
-          );
-          const indexOf = line.text.indexOf(
-            text.substring(test_keyword_start, i)
-          );
-          const position = new vscode.Position(line.lineNumber, indexOf);
-          const range = document.getWordRangeAtPosition(position, null);
-          this.codeLenses.push(
-            new vscode.CodeLens(range, {
-              title: "Run test",
-              command: "zig.test.run",
-              arguments: [
-                document.uri,
-                `"${text.substring(quote_start, quote_end)}"`,
-              ],
-              tooltip: "Run this test via zig test",
-            })
-          );
+        const line = document.lineAt(
+          document.positionAt(test_keyword_start).line
+        );
+        const indexOf = line.text.indexOf(
+          text.substring(test_keyword_start, i)
+        );
+        const position = new vscode.Position(line.lineNumber, indexOf);
+        const range = document.getWordRangeAtPosition(position, null);
+        this.codeLenses.push(
+          new vscode.CodeLens(range, {
+            title: "Run test",
+            command: "zig.test.run",
+            arguments: [
+              document.uri,
+              `"${text.substring(quote_start, quote_end)}"`,
+            ],
+            tooltip: "Run this test via zig test",
+          })
+        );
 
-          test_keyword_start = -1;
-          // test without a label
-        } else if (test_keyword_start > -1 && text[i] !== " ") {
-          const line = document.lineAt(
-            document.positionAt(test_keyword_start).line
-          );
-          const indexOf = line.text.indexOf(
-            text.substring(test_keyword_start, i)
-          );
-          const position = new vscode.Position(line.lineNumber, indexOf);
-          const range = document.getWordRangeAtPosition(position, null);
-          this.codeLenses.push(
-            new vscode.CodeLens(range, {
-              title: "Run test",
-              command: "zig.test.run",
-              arguments: [document.uri, ""],
-              tooltip: "Run this test via zig test",
-            })
-          );
-          test_keyword_start = -1;
+        test_keyword_start = -1;
+        // test without a label
+      } else if (test_keyword_start > -1 && text[i] !== " ") {
+        const line = document.lineAt(
+          document.positionAt(test_keyword_start).line
+        );
+        const indexOf = line.text.indexOf(
+          text.substring(test_keyword_start, i)
+        );
+        const position = new vscode.Position(line.lineNumber, indexOf);
+        const range = document.getWordRangeAtPosition(position, null);
+        this.codeLenses.push(
+          new vscode.CodeLens(range, {
+            title: "Run test",
+            command: "zig.test.run",
+            arguments: [document.uri, ""],
+            tooltip: "Run this test via zig test",
+          })
+        );
+        test_keyword_start = -1;
+      }
+
+      switch (text[i]) {
+        case "\n": {
+          was_newline = true;
+          break;
         }
 
-        switch (text[i]) {
-          case "\n": {
-            was_newline = true;
-            break;
-          }
-
-          case " ": {
-            break;
-          }
-          default: {
-            was_newline = false;
-            break;
-          }
+        case " ": {
+          break;
+        }
+        default: {
+          was_newline = false;
+          break;
         }
       }
     }
+
     return this.codeLenses;
   }
 }

--- a/src/zigCodeLensProvider.ts
+++ b/src/zigCodeLensProvider.ts
@@ -88,10 +88,9 @@ export class CodelensProvider implements vscode.CodeLensProvider {
         const range = document.getWordRangeAtPosition(position, null);
         this.codeLenses.push(
           new vscode.CodeLens(range, {
-            title: "Run test",
+            title: "Run all tests in file (and imports)",
             command: "zig.test.run",
             arguments: [document.uri, ""],
-            tooltip: "Run this test via zig test",
           })
         );
         test_keyword_start = -1;
@@ -111,6 +110,19 @@ export class CodelensProvider implements vscode.CodeLensProvider {
           break;
         }
       }
+    }
+
+    if (this.codeLenses.length > 0) {
+      const line = document.lineAt(document.positionAt(0).line);
+      const position = new vscode.Position(line.lineNumber, 0);
+      const range = document.getWordRangeAtPosition(position, null);
+      this.codeLenses.push(
+        new vscode.CodeLens(range, {
+          title: "Run all tests in file (and imports)",
+          command: "zig.test.run",
+          arguments: [document.uri, ""],
+        })
+      );
     }
 
     return this.codeLenses;

--- a/src/zigCodeLensProvider.ts
+++ b/src/zigCodeLensProvider.ts
@@ -1,0 +1,124 @@
+import * as vscode from "vscode";
+
+/**
+ * CodelensProvider
+ */
+export class CodelensProvider implements vscode.CodeLensProvider {
+  private codeLenses: vscode.CodeLens[] = [];
+  private _onDidChangeCodeLenses: vscode.EventEmitter<void> =
+    new vscode.EventEmitter<void>();
+  public readonly onDidChangeCodeLenses: vscode.Event<void> =
+    this._onDidChangeCodeLenses.event;
+
+  constructor() {
+    vscode.workspace.onDidChangeConfiguration((_) => {
+      this._onDidChangeCodeLenses.fire();
+    });
+  }
+
+  public provideCodeLenses(
+    document: vscode.TextDocument,
+    token: vscode.CancellationToken
+  ): vscode.CodeLens[] | Thenable<vscode.CodeLens[]> {
+    if (
+      vscode.workspace
+        .getConfiguration("codelens-sample")
+        .get("enableCodeLens", true)
+    ) {
+      this.codeLenses = [];
+      const text = document.getText();
+      let matches;
+
+      var was_newline = false;
+      var test_keyword_start = -1;
+      for (let i = 0; i < text.length; i++) {
+        // test "foo"
+        // ^
+        if (
+          was_newline &&
+          text.length > i + 4 &&
+          text[i] === "t" &&
+          text[i + 1] === "e" &&
+          text[i + 2] === "s" &&
+          text[i + 3] === "t" &&
+          (text[i + 4] === " " || text[i + 4] === "\n")
+        ) {
+          test_keyword_start = i;
+          i += 4;
+        }
+
+        // test "foo"
+        //      ^
+        if (test_keyword_start > -1 && text[i] === '"') {
+          i += 1;
+          const quote_start = i;
+
+          while (i < text.length && text[i] !== '"') {
+            if (text[i] === "\\" && text[i + 1] === '"') {
+              i += 1;
+            }
+            i += 1;
+          }
+          const quote_end = i;
+
+          const line = document.lineAt(
+            document.positionAt(test_keyword_start).line
+          );
+          const indexOf = line.text.indexOf(
+            text.substring(test_keyword_start, i)
+          );
+          const position = new vscode.Position(line.lineNumber, indexOf);
+          const range = document.getWordRangeAtPosition(position, null);
+          this.codeLenses.push(
+            new vscode.CodeLens(range, {
+              title: "Run test",
+              command: "zig.test.run",
+              arguments: [
+                document.uri,
+                `"${text.substring(quote_start, quote_end)}"`,
+              ],
+              tooltip: "Run this test via zig test",
+            })
+          );
+
+          test_keyword_start = -1;
+          // test without a label
+        } else if (test_keyword_start > -1 && text[i] !== " ") {
+          const line = document.lineAt(
+            document.positionAt(test_keyword_start).line
+          );
+          const indexOf = line.text.indexOf(
+            text.substring(test_keyword_start, i)
+          );
+          const position = new vscode.Position(line.lineNumber, indexOf);
+          const range = document.getWordRangeAtPosition(position, null);
+          this.codeLenses.push(
+            new vscode.CodeLens(range, {
+              title: "Run test",
+              command: "zig.test.run",
+              arguments: [document.uri, ""],
+              tooltip: "Run this test via zig test",
+            })
+          );
+          test_keyword_start = -1;
+        }
+
+        switch (text[i]) {
+          case "\n": {
+            was_newline = true;
+            break;
+          }
+
+          case " ": {
+            break;
+          }
+          default: {
+            was_newline = false;
+            break;
+          }
+        }
+      }
+    }
+    return this.codeLenses;
+  }
+}


### PR DESCRIPTION
This adds a "Run test" button above the `test` keyword. 
- It also enables the problem matcher to highlight any lines that caused semantic analysis to fail when building the test.
- It adds a flag `zig.testArgs` to let you pass additional arguments to tests
- It adds a flag `zig.disableProblemMatcherForTest` if you don't want the problem matcher to be enabled for tests


https://user-images.githubusercontent.com/709451/119283328-80f53c80-bbf1-11eb-8111-cdf0ccbccc09.mov

Screenshot incase the video doesn't load:
![image](https://user-images.githubusercontent.com/709451/119283379-ac782700-bbf1-11eb-9e92-764aace6f052.png)

It would be better to implement this via LSP, but I'm less familiar with that.