### PR TITLE
Update tsc line to generate .vsix file

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,6 @@ modify the `Zig Path` setting to point to the `zig` binary.
 
 ```
 npm install
-tsc src/extensions.js
+tsc src/extension.ts
 npx vsce package
 ```


### PR DESCRIPTION
src/extensions.js does not exist from a clean installation. Running tsc src/extension.ts writes a src/extension.js file (notice no 's' in extension).