### PR TITLE
Fix Git URL in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/zig-lang/vscode-zig"
+    "url": "https://github.com/ziglang/vscode-zig"
   },
   "engines": {
     "vscode": "^1.56.0"


### PR DESCRIPTION
### What
Change the Git URL in package.json to reference the `ziglang` GitHub org rather than the `zig-lang` GitHub org.

### Why
It looks like a typo, or it was hosted at a different org in the past.

Super minor, maybe has no impact, just noticed it when exploring the zig landscape.
