### PR TITLE
Add a link to the VSCode Extension on the Marketplace

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # vscode-zig
 
+![VSCode Extension](https://img.shields.io/badge/vscode-extension-brightgreen)
 ![CI](https://img.shields.io/github/workflow/status/ziglang/vscode-zig/CI.svg)
 
 [Zig](http://ziglang.org/) support for Visual Studio Code.


### PR DESCRIPTION
### What
Add a link to the VSCode Extension on the Marketplace in the README.

### Why
When I started exploring which extensions to install in VSCode I found it pretty confusing because there are a couple extensions on the VSCode Extension Marketplace. When viewing extensions I often like to checkout the GitHub page, but when I ended up at this GitHub repo I didn't see a corresponding link back to the marketplace to confirm which extension was definitely the released extension to this GitHub repo. Most people can probably infer it is the one released by Marc Tiehuis, but having a link here would provide some more confidence.