### PR TITLE
Add syntax highlighting for markdown fenced code block

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,17 @@
         "language": "zig",
         "scopeName": "source.zig",
         "path": "./syntaxes/zig.tmLanguage.json"
+      },
+      {
+        "language": "zig",
+        "scopeName": "markdown.zig.codeblock",
+        "path": "./syntaxes/codeblock.json",
+        "injectTo": [
+          "text.html.markdown"
+        ],
+        "embeddedLanguages": {
+          "meta.embedded.block.zig": "zig"
+        }
       }
     ],
     "problemMatchers": [

--- a/syntaxes/codeblock.json
+++ b/syntaxes/codeblock.json
@@ -1,0 +1,45 @@
+{
+	"fileTypes": [],
+	"injectionSelector": "L:text.html.markdown",
+	"patterns": [
+		{
+			"include": "#zig-code-block"
+		}
+	],
+	"repository": {
+		"zig-code-block": {
+			"begin": "(^|\\G)(\\s*)(\\`{3,}|~{3,})\\s*(?i:(zig)(\\s+[^`~]*)?$)",
+			"name": "markup.fenced_code.block.markdown",
+			"end": "(^|\\G)(\\2|\\s{0,3})(\\3)\\s*$",
+			"beginCaptures": {
+				"3": {
+					"name": "punctuation.definition.markdown"
+				},
+				"4": {
+					"name": "fenced_code.block.language.markdown"
+				},
+				"5": {
+					"name": "fenced_code.block.language.attributes.markdown"
+				}
+			},
+			"endCaptures": {
+				"3": {
+					"name": "punctuation.definition.markdown"
+				}
+			},
+			"patterns": [
+				{
+					"begin": "(^|\\G)(\\s*)(.*)",
+					"while": "(^|\\G)(?!\\s*([`~]{3,})\\s*$)",
+					"contentName": "meta.embedded.block.zig",
+					"patterns": [
+						{
+							"include": "source.zig"
+						}
+					]
+				}
+			]
+		}
+	},
+	"scopeName": "markdown.zig.codeblock"
+}


### PR DESCRIPTION
### Preview

| **Before** | **After** |
| :-- | :-- |
| ![](https://user-images.githubusercontent.com/8186898/180288689-e2fd7a35-c84f-4b7b-8901-a665d18e4514.png) | ![](https://user-images.githubusercontent.com/8186898/180288751-1b3974fc-adf6-4634-a81b-24b638b55a60.png) |
