### PR TITLE
Add aarch64 linux zls builds to extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.3.1
+- Fix missing Linux AArch64 ZLS auto-installer support
+
 ## 0.3.0
  - Update syntax to Zig 0.10.x
  - Add support for optional [Zig Language Server](https://github.com/zigtools/zls) integration

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-zig",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-zig",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.3.2",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-zig",
   "displayName": "Zig",
   "description": "Language support for the Zig programming language",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "publisher": "ziglang",
   "icon": "images/zig-icon.png",
   "license": "MIT",

--- a/src/zls.ts
+++ b/src/zls.ts
@@ -28,11 +28,12 @@ export enum InstallationName {
     x86_64_macos = "x86_64-macos",
     x86_64_windows = "x86_64-windows",
     arm_64_macos = "aarch64-macos",
+    arm_64_linux = "aarch64-linux",
 }
 /* eslint-enable @typescript-eslint/naming-convention */
 
 export function getDefaultInstallationName(): InstallationName | null {
-    // NOTE: Not using a JS switch because they"re very clunky :(
+    // NOTE: Not using a JS switch because they're very clunky :(
 
     const plat = process.platform;
     const arch = process.arch;
@@ -45,6 +46,7 @@ export function getDefaultInstallationName(): InstallationName | null {
         else if (plat === "win32") return InstallationName.x86_64_windows;
     } else if (arch === "arm64") {
         if (plat === "darwin") return InstallationName.arm_64_macos;
+        if (plat === "linux") return InstallationName.arm_64_linux;
     }
 
     return null;


### PR DESCRIPTION
This requires a new patch version be released, thus the version bump and changelog entry.