### PR TITLE
add `.zon` to associated file extensions

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "configurationDefaults": {
       "[zig]": {
         "editor.formatOnSave": true,
-        "editor.defaultFormatter": "ziglang.zig",
+        "editor.defaultFormatter": "ziglang.vscode-zig",
         "files.eol": "\n"
       }
     },
@@ -34,7 +34,8 @@
       {
         "id": "zig",
         "extensions": [
-          ".zig"
+          ".zig",
+          ".zon"
         ],
         "configuration": "./language-configuration.json"
       }

--- a/syntaxes/zig.tmLanguage.json
+++ b/syntaxes/zig.tmLanguage.json
@@ -3,7 +3,8 @@
   "name": "zig",
   "scopeName": "source.zig",
   "fileTypes": [
-    "zig"
+    "zig",
+    "zon"
   ],
   "patterns": [
     {


### PR DESCRIPTION
This will provide syntax highlighting for `.zon` files.