### PR TITLE
Fix `zls` not restarting after having been updated on macOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,7 @@
-## Next
-- Fix `zls` not restarting after having been updated on macOS (@ngrilly)
-
 ## 0.3.2
 - Make formatting provider option an enum (@alichraghi)
 - Only apply onEnterRules when line starts with whitespace
+- Fix `zls` not restarting after having been updated on macOS (@ngrilly)
 
 ## 0.3.1
 - Fix missing Linux AArch64 ZLS auto-installer support

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## Next
+- Fix `zls` not restarting after having been updated on macOS (@ngrilly)
+
 ## 0.3.2
 - Make formatting provider option an enum (@alichraghi)
 - Only apply onEnterRules when line starts with whitespace


### PR DESCRIPTION
On macOS, `zls` is sometimes unable to restart after having been updated  using the command "Zig Language Server: Install Server". The fix is create a new executable file, instead of updating the existing executable file in place, the latter causing a code-signing crash if the kernel is caching the signature.