### PR TITLE
Support `${workspaceFolder}` in `zig.zls.path`

### DIFF
--- a/package.json
+++ b/package.json
@@ -176,7 +176,7 @@
         "zig.zls.path": {
           "scope": "resource",
           "type": "string",
-          "description": "Path to `zls` executable. Example: `C:/zls/zig-cache/bin/zls.exe`.",
+          "description": "Path to `zls` executable. Example: `C:/zls/zig-cache/bin/zls.exe`. If ${workspaceFolder} is used, it will be resolve to the first workspace folder.",
           "format": "path"
         },
         "zig.zls.debugLog": {


### PR DESCRIPTION
This allows [`${workspaceFolder}`](https://code.visualstudio.com/docs/editor/variables-reference#_predefined-variables) to be used in the `zig.zls.path` config setting

We want to rely on a specific version of zls because the auto-updater causes zls to randomly break in our project.

To do that we have a script that downloads and compiles the exact version used. I tried using a relative path but zls couldn't find it (possibly the cwd is not the workspace root)



