### PR TITLE
fix specify path adds leading slash on windows

### DIFF
--- a/src/zigSetup.ts
+++ b/src/zigSetup.ts
@@ -193,7 +193,7 @@ export async function setupZig(context: ExtensionContext) {
             });
 
             if (uris) {
-                await configuration.update("zigPath", uris[0].path, true);
+                await configuration.update("zigPath", uris[0].fsPath, true);
             }
         }
     }


### PR DESCRIPTION
uri.path adds a leading slash on windows when selecting the zig executable. This causes zls to crash, which is most likely the crash reported in #115.

It's very likely that more uri.path usages are wrong and should become uri.fsPath. 

Relevant API documentation: https://code.visualstudio.com/api/references/vscode-api#Uri