### PR TITLE
add option to always search for zig in PATH

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 - Fix checking for ZLS updates
+- Always check `PATH` when `zigPath` is set to empty string
 
 ## 0.4.2
 - Fix `Specify path` adding a leading slash on windows (@sebastianhoffmann)

--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
         "zig.zigPath": {
           "type": "string",
           "default": null,
-          "description": "Set a custom path to the Zig binary."
+          "description": "Set a custom path to the Zig binary. Empty string will lookup zig in PATH."
         },
         "zig.zigVersion": {
           "type": "string",

--- a/src/zigBuild.ts
+++ b/src/zigBuild.ts
@@ -1,6 +1,7 @@
 import { buildDiagnosticCollection, logChannel } from './extension';
 import * as cp from 'child_process';
 import * as vscode from 'vscode';
+import { getZigPath } from './zigUtil';
 
 export function zigBuild(): void {
     const editor = vscode.window.activeTextEditor;
@@ -28,7 +29,7 @@ export function zigBuild(): void {
     });
 
     const cwd = vscode.workspace.getWorkspaceFolder(editor.document.uri).uri.fsPath;
-    const buildPath = config.get<string>("zigPath");
+    const buildPath = getZigPath();
 
     logChannel.appendLine(`Starting building the current workspace at ${cwd}`);
 

--- a/src/zigCompilerProvider.ts
+++ b/src/zigCompilerProvider.ts
@@ -5,6 +5,7 @@ import * as cp from "child_process";
 import * as vscode from "vscode";
 // This will be treeshaked to only the debounce function
 import { throttle } from "lodash-es";
+import { getZigPath } from "./zigUtil";
 
 export default class ZigCompilerProvider implements vscode.CodeActionProvider {
   private buildDiagnostics: vscode.DiagnosticCollection;
@@ -58,16 +59,15 @@ export default class ZigCompilerProvider implements vscode.CodeActionProvider {
   }
 
   private _doASTGenErrorCheck(change: vscode.TextDocumentChangeEvent) {
-    let config = vscode.workspace.getConfiguration("zig");
     const textDocument = change.document;
     if (textDocument.languageId !== "zig") {
       return;
     }
-    const zig_path = config.get("zigPath");
+    const zigPath = getZigPath();
     const cwd = vscode.workspace.getWorkspaceFolder(textDocument.uri).uri
       .fsPath;
 
-    let childProcess = cp.spawn(zig_path as string, ["ast-check"], { cwd });
+    let childProcess = cp.spawn(zigPath, ["ast-check"], { cwd });
 
     if (!childProcess.pid) {
       return;

--- a/src/zigFormat.ts
+++ b/src/zigFormat.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode';
 import { TextEdit, OutputChannel } from 'vscode';
-import { execCmd } from './zigUtil';
+import { execCmd, getZigPath } from './zigUtil';
 
 export class ZigFormatProvider implements vscode.DocumentFormattingEditProvider {
     private _channel: OutputChannel;
@@ -80,8 +80,7 @@ export class ZigRangeFormatProvider implements vscode.DocumentRangeFormattingEdi
 }
 
 function zigFormat(document: vscode.TextDocument) {
-    const config = vscode.workspace.getConfiguration("zig");
-    const zigPath = config.get<string>("zigPath");
+    const zigPath = getZigPath();
 
     const options = {
         cmdArguments: ['fmt', '--stdin'],

--- a/src/zigSetup.ts
+++ b/src/zigSetup.ts
@@ -172,13 +172,10 @@ export async function setupZig(context: ExtensionContext) {
     });
 
     const configuration = workspace.getConfiguration("zig", null);
-    if (!configuration.get<string | null>("zigPath", null)) {
-        const zigInPath = which.sync("zig", { nothrow: true });
-        const options = ["Install", "Specify path"];
-        if (zigInPath) options.push("Use Zig in PATH");
+    if (configuration.get<string | null>("zigPath", null) === null) {
         const response = await window.showInformationMessage(
             "Zig path hasn't been set, do you want to specify the path or install Zig?",
-            ...options
+            "Install", "Specify path", "Use Zig in PATH"
         );
 
         if (response === "Install") {
@@ -200,7 +197,7 @@ export async function setupZig(context: ExtensionContext) {
                 await configuration.update("zigPath", uris[0].fsPath, true);
             }
         } else if (response == "Use Zig in PATH") {
-            await configuration.update("zigPath", zigInPath, true);
+            await configuration.update("zigPath", "", true);
         } else throw "zigPath not specified";
     }
 

--- a/src/zigUtil.ts
+++ b/src/zigUtil.ts
@@ -2,6 +2,7 @@ import * as cp from 'child_process';
 import * as fs from 'fs';
 import * as path from 'path';
 import { window, workspace } from 'vscode';
+import which from 'which';
 
 export const isWindows = process.platform === 'win32';
 
@@ -50,7 +51,7 @@ export function execCmd
     let cmdArguments = options ? options.cmdArguments : [];
 
     childProcess =
-      cp.execFile(cmd, cmdArguments, { cwd: detectProjectRoot(fileName || workspace.rootPath + '/fakeFileName'), maxBuffer: 10 * 1024 * 1024}, handleExit);
+      cp.execFile(cmd, cmdArguments, { cwd: detectProjectRoot(fileName || workspace.rootPath + '/fakeFileName'), maxBuffer: 10 * 1024 * 1024 }, handleExit);
 
 
     childProcess.stdout.on('data', (data: Buffer) => {
@@ -142,4 +143,17 @@ export function detectProjectRoot(fileName: string): string {
     return proj;
   }
   return undefined;
+}
+
+export function getZigPath(): string {
+  const configuration = workspace.getConfiguration("zig");
+  let zigPath = configuration.get<string | null>("zigPath", null);
+  if (!zigPath) {
+    zigPath = which.sync("zig", { nothrow: true });
+    if (!zigPath) {
+      window.showErrorMessage("zig not found in PATH");
+      throw "zig not found in PATH";
+    }
+  }
+  return zigPath;
 }


### PR DESCRIPTION
Closes #119

This also makes the options for zls more obvious, but I'm not quite sure how to best handle not finding a Zig executable.