### PR TITLE
add json validation for zls.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -388,6 +388,12 @@
         "title": "Check for Server Updates",
         "category": "Zig Language Server"
       }
+    ],
+    "jsonValidation": [
+      {
+        "fileMatch": "zls.json",
+        "url": "https://raw.githubusercontent.com/zigtools/zls/master/schema.json"
+      }
     ]
   },
   "scripts": {


### PR DESCRIPTION
This will provide IntelliSense and validation in `zls.json` without needing to specifying `$schema`.