### PR TITLE
Delete old zls binary before renaming to avoid Windows permission error

### DIFF
--- a/src/zls.ts
+++ b/src/zls.ts
@@ -83,6 +83,7 @@ export async function installExecutable(context: ExtensionContext): Promise<stri
         // https://developer.apple.com/documentation/security/updating_mac_software
         fs.writeFileSync(zlsBinTempPath, exe, "binary");
         fs.chmodSync(zlsBinTempPath, 0o755);
+        if (fs.existsSync(zlsBinPath)) fs.rmSync(zlsBinPath);
         fs.renameSync(zlsBinTempPath, zlsBinPath);
 
         let config = workspace.getConfiguration("zig.zls");


### PR DESCRIPTION
@MangoDev1 ran into a Windows permission issue, this fix seemed to work.