### PR TITLE
Fix C pointer highlighting in the hover widget

### DIFF
--- a/syntaxes/zig.tmLanguage.json
+++ b/syntaxes/zig.tmLanguage.json
@@ -180,7 +180,7 @@
       "patterns": [
         {
           "name": "keyword.operator.c-pointer.zig",
-          "match": "\\[*c\\]"
+          "match": "(?<=\\[)\\*c(?=\\])"
         },
         {
           "name": "keyword.operator.comparison.zig",


### PR DESCRIPTION
The existing regex pattern (`"\\[*c\\]"`) for C pointers is wrong as the asterisk is not escaped. This worked fine in the editor somehow, but shows weird highlighting in the hover widget.

This PR fixes it to highlight `*c` inside `[]` correctly.

Before:
![Screenshot_20231011_152651](https://github.com/ziglang/vscode-zig/assets/22029524/7e4c20bd-dd2e-4a10-b1fa-947a3879bed8)
After:
![Screenshot_20231011_152755](https://github.com/ziglang/vscode-zig/assets/22029524/416964a1-0b40-41e2-975a-6b67f0236c5b)
