### PR TITLE
Make `zig.zls.path` scoped as `machine-overridable`.

### DIFF
--- a/package.json
+++ b/package.json
@@ -179,7 +179,7 @@
           "default": true
         },
         "zig.zls.path": {
-          "scope": "resource",
+          "scope": "machine-overridable",
           "type": "string",
           "description": "Path to `zls` executable. Example: `C:/zls/zig-cache/bin/zls.exe`.",
           "format": "path"

--- a/package.json
+++ b/package.json
@@ -104,6 +104,7 @@
           "description": "The path to build.zig. This is only required if zig.buildOptions = build."
         },
         "zig.path": {
+          "scope": "machine-overridable",
           "type": "string",
           "default": null,
           "description": "Set a custom path to the Zig binary. Empty string will lookup zig in PATH."


### PR DESCRIPTION
This prevents it from being synced between machines by default, which is undesirable for people who switch between e.g. Windows and Linux.

This change aligns with how vscode-clangd handles its `clangd.path` setting, as an example: https://github.com/clangd/vscode-clangd/blob/eca1e05a39c4e987dca6247d825dfbe92fd5996f/package.json#L97-L102