### PR TITLE
Make `zig.path` and `zig.zls.path` default to `""` (look up in `PATH`).

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
         "zig.path": {
           "scope": "machine-overridable",
           "type": "string",
-          "default": null,
+          "default": "",
           "description": "Set a custom path to the Zig binary. Empty string will lookup zig in PATH."
         },
         "zig.checkForUpdate": {
@@ -182,6 +182,7 @@
         "zig.zls.path": {
           "scope": "machine-overridable",
           "type": "string",
+          "default": "",
           "description": "Path to `zls` executable. Example: `C:/zls/zig-cache/bin/zls.exe`.",
           "format": "path"
         },


### PR DESCRIPTION
* These will be overwritten by the initial setup process anyway.
* This at least ensures that the default value doesn't cause a warning when editing `settings.json`.
* Looking these programs up in `PATH` seems like a sensible default and is consistent with many other extensions.

Closes #157.