### PR TITLE
Use `zig.zls` as the language client ID and rename trace setting accordingly.

### DIFF
--- a/package.json
+++ b/package.json
@@ -161,7 +161,7 @@
           ],
           "default": "extension"
         },
-        "zig.trace.server": {
+        "zig.zls.trace.server": {
           "scope": "window",
           "type": "string",
           "description": "Traces the communication between VS Code and the language server.",

--- a/src/zls.ts
+++ b/src/zls.ts
@@ -72,7 +72,7 @@ async function startClient() {
 
     // Create the language client and start the client.
     client = new LanguageClient(
-        "zls",
+        "zig.zls",
         "Zig Language Server",
         serverOptions,
         clientOptions


### PR DESCRIPTION
Closes #99.