### PR TITLE
update ZLS configuration options

### DIFF
--- a/package.json
+++ b/package.json
@@ -120,27 +120,6 @@
           "default": true,
           "description": "Should output channel be raised on formatting error."
         },
-        "zig.astCheckProvider": {
-          "scope": "resource",
-          "type": "string",
-          "description": "Whether to enable ast-check diagnostics",
-          "enum": [
-            "off",
-            "extension",
-            "zls"
-          ],
-          "enumItemLabels": [
-            "Off",
-            "Extension",
-            "Zig Language Server"
-          ],
-          "enumDescriptions": [
-            "Disable ast-check diagnostics",
-            "Use extension ast-check diagnostics (fewer features)",
-            "Use ZLS ast-check diagnostics (includes code actions)"
-          ],
-          "default": "zls"
-        },
         "zig.formattingProvider": {
           "scope": "resource",
           "type": "string",
@@ -198,17 +177,17 @@
           "description": "Whether to enable function argument placeholder completions",
           "default": true
         },
-        "zig.zls.enableAstCheckDiagnostics": {
-          "scope": "resource",
-          "type": "boolean",
-          "description": "Whether to enable ast-check diagnostics",
-          "default": true
-        },
         "zig.zls.enableBuildOnSave": {
           "scope": "resource",
           "type": "boolean",
           "description": "Whether to enable build-on-save diagnostics",
           "default": false
+        },
+        "zig.zls.buildOnSaveStep": {
+          "scope": "resource",
+          "type": "string",
+          "description": "Select which step should be executed on build-on-save",
+          "default": "install"
         },
         "zig.zls.enableAutofix": {
           "scope": "resource",
@@ -233,10 +212,10 @@
           "description": "Enables inlay hint support when the client also supports it",
           "default": true
         },
-        "zig.zls.inlayHintsShowVariableDeclaration": {
+        "zig.zls.inlayHintsShowVariableTypeHints": {
           "scope": "resource",
           "type": "boolean",
-          "description": "Enable inlay hints for variable declarations",
+          "description": "Enable inlay hints for variable types",
           "default": true
         },
         "zig.zls.inlayHintsShowParameterName": {
@@ -296,7 +275,7 @@
         "zig.zls.preferAstCheckAsChildProcess": {
           "scope": "resource",
           "type": "boolean",
-          "description": "Can be used in conjuction with `enable_ast_check_diagnostics` to favor using `zig ast-check` instead of ZLS's fork",
+          "description": "Favor using `zig ast-check` instead of ZLS's fork",
           "default": true
         },
         "zig.zls.recordSession": {
@@ -351,6 +330,12 @@
           "scope": "resource",
           "type": "boolean",
           "description": "Completions confirm behavior. If 'true', replace the text after the cursor",
+          "default": true
+        },
+        "zig.zls.completionLabelDetails": {
+          "scope": "resource",
+          "type": "boolean",
+          "description": "When false, the function signature of completion results is hidden. Improves readability in some editors",
           "default": true
         }
       }

--- a/src/zigCompilerProvider.ts
+++ b/src/zigCompilerProvider.ts
@@ -3,6 +3,7 @@
 import * as cp from "child_process";
 import * as path from "path";
 import * as vscode from "vscode";
+import * as zls from "./zls";
 // This will be treeshaked to only the debounce function
 import { throttle } from "lodash-es";
 import Path from "path";
@@ -24,7 +25,7 @@ export default class ZigCompilerProvider implements vscode.CodeActionProvider {
 
     maybeDoASTGenErrorCheck(change: vscode.TextDocumentChangeEvent) {
         if (change.document.languageId !== "zig") {return;}
-        if (vscode.workspace.getConfiguration("zig").get<string>("astCheckProvider") !== "extension") {
+        if (zls.client !== null) {
             this.astDiagnostics.clear();
             return;
         }

--- a/src/zls.ts
+++ b/src/zls.ts
@@ -15,7 +15,7 @@ import {
 import { getExePath, getHostZigName, getVersion, getZigPath, isWindows, shouldCheckUpdate } from "./zigUtil";
 
 let outputChannel: vscode.OutputChannel;
-let client: LanguageClient | null = null;
+export let client: LanguageClient | null = null;
 
 async function startClient() {
     const configuration = workspace.getConfiguration("zig.zls");
@@ -35,15 +35,12 @@ async function startClient() {
         middleware: {
             workspace: {
                 async configuration(params, token, next) {
-                    let indexOfAstCheck = null;
                     let indexOfZigPath = null;
 
                     for (const [index, param] of Object.entries(params.items)) {
                         if (param.section === "zls.zig_exe_path") {
                             param.section = "zig.path";
                             indexOfZigPath = index;
-                        } else if (param.section === "zls.enable_ast_check_diagnostics") {
-                            indexOfAstCheck = index;
                         } else {
                             param.section = `zig.zls.${camelCase(param.section.slice(4))}`;
                         }
@@ -51,9 +48,6 @@ async function startClient() {
 
                     const result = await next(params, token);
 
-                    if (indexOfAstCheck !== null) {
-                        result[indexOfAstCheck] = workspace.getConfiguration("zig").get<string>("astCheckProvider") === "zls";
-                    }
                     if (indexOfZigPath !== null) {
                         try {
                             result[indexOfZigPath] = getZigPath();


### PR DESCRIPTION
The `enable_ast_check_diagnostics` option has been removed which makes the `astCheckProvider` option obsolete.