### PR TITLE
fix: use getZigPath to determine if zls.install is available

### DIFF
--- a/src/zls.ts
+++ b/src/zls.ts
@@ -245,8 +245,13 @@ export async function activate(context: ExtensionContext) {
     outputChannel = window.createOutputChannel("Zig Language Server");
 
     vscode.commands.registerCommand("zig.zls.install", async () => {
-        if (workspace.getConfiguration("zig").get<string>("path") === undefined) {
-            window.showErrorMessage("This command cannot be run without setting 'zig.path'.", { modal: true });
+        try {
+            getZigPath();
+        } catch {
+            window.showErrorMessage(
+                "This command cannot be run without a valid zig path.",
+                { modal: true }
+            );
             return;
         }
 


### PR DESCRIPTION
getZigPath also get zig path from environment instead of checking the configure. And the install function calls getZigPath, which ensures unity for the two places.