### PR TITLE
fix detection of unset path options

### DIFF
--- a/package.json
+++ b/package.json
@@ -167,7 +167,7 @@
           "scope": "machine-overridable",
           "type": "string",
           "default": "",
-          "description": "Path to `zls` executable. Example: `C:/zls/zig-cache/bin/zls.exe`.",
+          "description": "Path to `zls` executable. Example: `C:/zls/zig-cache/bin/zls.exe`. Empty string will lookup ZLS in PATH.",
           "format": "path"
         },
         "zig.zls.enableSnippets": {

--- a/src/zigSetup.ts
+++ b/src/zigSetup.ts
@@ -232,7 +232,7 @@ export async function setupZig(context: vscode.ExtensionContext) {
 async function initialSetup(context: vscode.ExtensionContext): Promise<boolean> {
     const zigConfig = vscode.workspace.getConfiguration("zig");
 
-    if (!zigConfig.has("path")) {
+    if (zigConfig.get<string>("path") === "") {
         const zigResponse = await vscode.window.showInformationMessage(
             "Zig path hasn't been set, do you want to specify the path or install Zig?",
             { modal: true },
@@ -273,7 +273,7 @@ async function initialSetup(context: vscode.ExtensionContext): Promise<boolean> 
 
     const zlsConfig = vscode.workspace.getConfiguration("zig.zls");
 
-    if (!zlsConfig.has("path")) {
+    if (zlsConfig.get<string>("path") === "") {
         const zlsResponse = await vscode.window.showInformationMessage(
             "We recommend enabling ZLS (the Zig Language Server) for a better editing experience. Would you like to install it?",
             { modal: true },


### PR DESCRIPTION
`zig.path` and `zig.zls.path` default to an empty string instead of null when unset so the previous check would skip the initial setup. Unfortunately this makes it impossible to differentiate between an unset path and lookup in $PATH.