### PR TITLE
Add Zig to PATH in integrated terminal

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "@types/lodash-es": "^4.17.12",
         "@types/mocha": "^2.2.48",
         "@types/node": "^18.0.0",
-        "@types/vscode": "^1.68.0",
+        "@types/vscode": "^1.80.0",
         "@types/which": "^2.0.1",
         "@vscode/vsce": "^2.24.0",
         "esbuild": "^0.12.1",
@@ -33,7 +33,7 @@
         "vscode-test": "^1.4.0"
       },
       "engines": {
-        "vscode": "^1.68.0"
+        "vscode": "^1.76.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -267,9 +267,9 @@
       "dev": true
     },
     "node_modules/@types/vscode": {
-      "version": "1.75.0",
-      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.75.0.tgz",
-      "integrity": "sha512-SAr0PoOhJS6FUq5LjNr8C/StBKALZwDVm3+U4pjF/3iYkt3GioJOPV/oB1Sf1l7lROe4TgrMyL5N1yaEgTWycw==",
+      "version": "1.80.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.80.0.tgz",
+      "integrity": "sha512-qK/CmOdS2o7ry3k6YqU4zD3R2AYlJfbwBoSbKpBoP+GpXNE+0NEgJOli4n0bm0diK5kfBnchgCEj4igQz/44Hg==",
       "dev": true
     },
     "node_modules/@types/which": {
@@ -3508,9 +3508,9 @@
       "dev": true
     },
     "@types/vscode": {
-      "version": "1.75.0",
-      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.75.0.tgz",
-      "integrity": "sha512-SAr0PoOhJS6FUq5LjNr8C/StBKALZwDVm3+U4pjF/3iYkt3GioJOPV/oB1Sf1l7lROe4TgrMyL5N1yaEgTWycw==",
+      "version": "1.80.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.80.0.tgz",
+      "integrity": "sha512-qK/CmOdS2o7ry3k6YqU4zD3R2AYlJfbwBoSbKpBoP+GpXNE+0NEgJOli4n0bm0diK5kfBnchgCEj4igQz/44Hg==",
       "dev": true
     },
     "@types/which": {

--- a/package.json
+++ b/package.json
@@ -11,13 +11,12 @@
     "url": "https://github.com/ziglang/vscode-zig"
   },
   "engines": {
-    "vscode": "^1.68.0"
+    "vscode": "^1.80.0"
   },
   "categories": [
     "Programming Languages"
   ],
   "activationEvents": [
-    "onLanguage:zig",
     "workspaceContains:*/build.zig",
     "workspaceContains:*/build.zig.zon"
   ],
@@ -409,7 +408,7 @@
     "@types/lodash-es": "^4.17.12",
     "@types/mocha": "^2.2.48",
     "@types/node": "^18.0.0",
-    "@types/vscode": "^1.68.0",
+    "@types/vscode": "^1.80.0",
     "@types/which": "^2.0.1",
     "@vscode/vsce": "^2.24.0",
     "esbuild": "^0.12.1",


### PR DESCRIPTION
It turns out, VS Code already has an API to modify environment variables in the integrated terminal. If only it was documented somewhere :disappointed: 

The VS Code version has been bumped to `1.80.0` which is when the `description` field became available.

closes #171
fixes #159 (except that you are not being asked about it)