### PR TITLE
Fix ZLS config path condition

### DIFF
--- a/src/zls.ts
+++ b/src/zls.ts
@@ -330,7 +330,7 @@ export async function activate(context: vscode.ExtensionContext) {
     }, context.subscriptions);
 
     const zlsConfig = vscode.workspace.getConfiguration("zig.zls");
-    if (!zlsConfig.get<string>("path")) return;
+    if (zlsConfig.get<string>("path") === undefined) return;
     if (zlsConfig.get<boolean>("checkForUpdate") && (await shouldCheckUpdate(context, "zlsUpdate"))) {
         await checkUpdate(context);
     }


### PR DESCRIPTION
Hi :)

ZLS was broken for me after 0.5.4 and I think that I tracked down the bug...

I don't have `zig.zls.path` set so `!zlsConfig.get<string>("path")` (empty string) would evaluate to `true` and the code would return.
However it should be `false` and not return because of the lookup from PATH.
The check was `zlsConfig.get<string>("path") === undefined` before and with that it works again.