### PR TITLE
properly differentiate between lookup in PATH and an unset path option

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,7 @@
         "vscode-test": "^1.4.0"
       },
       "engines": {
-        "vscode": "^1.76.0"
+        "vscode": "^1.80.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -104,8 +104,11 @@
         },
         "zig.path": {
           "scope": "machine-overridable",
-          "type": "string",
-          "default": "",
+          "type": [
+            "string",
+            "null"
+          ],
+          "default": null,
           "description": "Set a custom path to the Zig binary. Empty string will lookup zig in PATH."
         },
         "zig.checkForUpdate": {
@@ -164,8 +167,11 @@
         },
         "zig.zls.path": {
           "scope": "machine-overridable",
-          "type": "string",
-          "default": "",
+          "type": [
+            "string",
+            "null"
+          ],
+          "default": null,
           "description": "Path to `zls` executable. Example: `C:/zls/zig-cache/bin/zls.exe`. Empty string will lookup ZLS in PATH.",
           "format": "path"
         },

--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
             "null"
           ],
           "default": null,
-          "description": "Set a custom path to the Zig binary. Empty string will lookup zig in PATH."
+          "description": "Set a custom path to the Zig binary. The string \"zig\" means lookup zig in PATH."
         },
         "zig.checkForUpdate": {
           "scope": "resource",
@@ -172,7 +172,7 @@
             "null"
           ],
           "default": null,
-          "description": "Path to `zls` executable. Example: `C:/zls/zig-cache/bin/zls.exe`. Empty string will lookup ZLS in PATH.",
+          "description": "Path to `zls` executable. Example: `C:/zls/zig-cache/bin/zls.exe`. The string \"zls\" means lookup ZLS in PATH.",
           "format": "path"
         },
         "zig.zls.enableSnippets": {

--- a/src/zigUtil.ts
+++ b/src/zigUtil.ts
@@ -21,7 +21,7 @@ export function getExePath(exePath: string | null, exeName: string, optionName: 
         }
     }
 
-    if (!exePath) {
+    if (exePath === null) {
         exePath = which.sync(exeName, { nothrow: true });
     } else if (exePath.startsWith("~")) {
         exePath = path.join(os.homedir(), exePath.substring(1));
@@ -30,7 +30,7 @@ export function getExePath(exePath: string | null, exeName: string, optionName: 
     }
 
     let message;
-    if (!exePath) {
+    if (exePath === null) {
         message = `Could not find ${exeName} in PATH`;
     } else if (!fs.existsSync(exePath)) {
         message = `\`${optionName}\` ${exePath} does not exist`;
@@ -49,7 +49,8 @@ export function getExePath(exePath: string | null, exeName: string, optionName: 
 export function getZigPath(): string {
     const configuration = vscode.workspace.getConfiguration("zig");
     const zigPath = configuration.get<string | null>("path", null);
-    return getExePath(zigPath, "zig", "zig.path");
+    const exePath = zigPath !== "zig" ? zigPath : null; // the string "zig" means lookup in PATH
+    return getExePath(exePath, "zig", "zig.path");
 }
 
 // Check timestamp `key` to avoid automatically checking for updates

--- a/src/zigUtil.ts
+++ b/src/zigUtil.ts
@@ -48,7 +48,7 @@ export function getExePath(exePath: string | null, exeName: string, optionName: 
 
 export function getZigPath(): string {
     const configuration = vscode.workspace.getConfiguration("zig");
-    const zigPath = configuration.get<string>("path") ?? null;
+    const zigPath = configuration.get<string | null>("path", null);
     return getExePath(zigPath, "zig", "zig.path");
 }
 

--- a/src/zls.ts
+++ b/src/zls.ts
@@ -73,7 +73,8 @@ export async function stopClient() {
 export function getZLSPath(): string {
     const configuration = vscode.workspace.getConfiguration("zig.zls");
     const zlsPath = configuration.get<string | null>("path", null);
-    return getExePath(zlsPath, "zls", "zig.zls.path");
+    const exePath = zlsPath !== "zls" ? zlsPath : null; // the string "zls" means lookup in PATH
+    return getExePath(exePath, "zls", "zig.zls.path");
 }
 
 async function configurationMiddleware(


### PR DESCRIPTION
`zig.path` and `zig.zls.path` default to an empty string which makes it impossible to differentiate between an unset value and lookup in PATH.

The following issues will also be resolved:
- initial setup asks about Zig and ZLS even when using lookup in PATH
- initial setup returns early after installing Zig
- `checkInstalled` would error when ZLS is used from PATH