### PR TITLE
remove output channel for `zig fmt`

### DIFF
--- a/package.json
+++ b/package.json
@@ -114,11 +114,6 @@
           "description": "Whether to automatically check for new updates",
           "default": true
         },
-        "zig.revealOutputChannelOnFormattingError": {
-          "type": "boolean",
-          "default": true,
-          "description": "Should output channel be raised on formatting error."
-        },
         "zig.formattingProvider": {
           "scope": "resource",
           "type": "string",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -7,32 +7,20 @@ import { setupZig } from "./zigSetup";
 
 const ZIG_MODE: vscode.DocumentFilter = { language: "zig", scheme: "file" };
 
-export let buildDiagnosticCollection: vscode.DiagnosticCollection;
-export const logChannel = vscode.window.createOutputChannel("zig");
-export const zigFormatStatusBar = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left);
-
 export async function activate(context: vscode.ExtensionContext) {
     await setupZig(context).finally(() => {
         const compiler = new ZigCompilerProvider();
         compiler.activate(context.subscriptions);
         vscode.languages.registerCodeActionsProvider("zig", compiler);
 
-        context.subscriptions.push(logChannel);
-
         if (vscode.workspace.getConfiguration("zig").get<string>("formattingProvider") === "extension") {
             context.subscriptions.push(
-                vscode.languages.registerDocumentFormattingEditProvider(ZIG_MODE, new ZigFormatProvider(logChannel)),
+                vscode.languages.registerDocumentFormattingEditProvider(ZIG_MODE, new ZigFormatProvider()),
             );
             context.subscriptions.push(
-                vscode.languages.registerDocumentRangeFormattingEditProvider(
-                    ZIG_MODE,
-                    new ZigRangeFormatProvider(logChannel),
-                ),
+                vscode.languages.registerDocumentRangeFormattingEditProvider(ZIG_MODE, new ZigRangeFormatProvider()),
             );
         }
-
-        buildDiagnosticCollection = vscode.languages.createDiagnosticCollection("zig");
-        context.subscriptions.push(buildDiagnosticCollection);
 
         void activateZls(context);
     });

--- a/src/zigFormat.ts
+++ b/src/zigFormat.ts
@@ -5,52 +5,27 @@ import childProcess from "child_process";
 import { getZigPath } from "./zigUtil";
 
 export class ZigFormatProvider implements vscode.DocumentFormattingEditProvider {
-    private _channel: vscode.OutputChannel;
-
-    constructor(logChannel: vscode.OutputChannel) {
-        this._channel = logChannel;
-    }
-
-    async provideDocumentFormattingEdits(document: vscode.TextDocument): Promise<vscode.TextEdit[] | null> {
-        return Promise.resolve(zigFormat(document, this._channel));
+    provideDocumentFormattingEdits(document: vscode.TextDocument): Promise<vscode.TextEdit[] | null> {
+        return Promise.resolve(zigFormat(document));
     }
 }
 
 // Same as full document formatter for now
 export class ZigRangeFormatProvider implements vscode.DocumentRangeFormattingEditProvider {
-    private _channel: vscode.OutputChannel;
-    constructor(logChannel: vscode.OutputChannel) {
-        this._channel = logChannel;
-    }
-
     provideDocumentRangeFormattingEdits(document: vscode.TextDocument): Promise<vscode.TextEdit[] | null> {
-        return Promise.resolve(zigFormat(document, this._channel));
+        return Promise.resolve(zigFormat(document));
     }
 }
 
-function zigFormat(document: vscode.TextDocument, logChannel: vscode.OutputChannel): vscode.TextEdit[] | null {
+function zigFormat(document: vscode.TextDocument): vscode.TextEdit[] | null {
     const zigPath = getZigPath();
 
-    const { error, stdout, stderr } = childProcess.spawnSync(zigPath, ["fmt", "--stdin"], {
+    const stdout = childProcess.execFileSync(zigPath, ["fmt", "--stdin"], {
         input: document.getText(),
         maxBuffer: 10 * 1024 * 1024, // 10MB
         encoding: "utf8",
         timeout: 60000, // 60 seconds (this is a very high value because 'zig fmt' is just in time compiled)
     });
-
-    if (error) {
-        const config = vscode.workspace.getConfiguration("zig");
-        logChannel.clear();
-        if (stderr.length !== 0) {
-            logChannel.appendLine(stderr.replace("<stdin>", document.fileName));
-            if (config.get<boolean>("revealOutputChannelOnFormattingError")) {
-                logChannel.show(true);
-            }
-        } else {
-            void vscode.window.showErrorMessage(error.message);
-        }
-        return null;
-    }
 
     if (stdout.length === 0) return null;
     const lastLineId = document.lineCount - 1;


### PR DESCRIPTION
This feature is no longer necessary since the extension can provide ast-check diagnostics.

closes #191