### PR TITLE
Switch `zig.zls.semanticTokens` default from `partial` to `full`.

### DIFF
--- a/package.json
+++ b/package.json
@@ -201,7 +201,7 @@
             "partial",
             "full"
           ],
-          "default": "partial"
+          "default": "full"
         },
         "zig.zls.enableInlayHints": {
           "scope": "resource",


### PR DESCRIPTION
To align with the ZLS change: https://github.com/zigtools/zls/commit/61b42ca63a118c085ee934cd70d3666bd437db4a