### PR TITLE
Document that `partial` is better than `full` for `zig.zls.semanticTokens`.

### DIFF
--- a/package.json
+++ b/package.json
@@ -195,7 +195,7 @@
         "zig.zls.semanticTokens": {
           "scope": "resource",
           "type": "string",
-          "description": "Set level of semantic tokens. Partial only includes information that requires semantic analysis.",
+          "description": "Set level of semantic tokens. `partial` only includes information that requires semantic analysis; this will usually give a better result than `full` in VS Code thanks to the Zig extension's syntax file.",
           "enum": [
             "none",
             "partial",


### PR DESCRIPTION
https://github.com/zigtools/zls/issues/338

Instead of https://github.com/ziglang/vscode-zig/pull/205.