### PR TITLE
Highlight bitwise not `~` operator

### DIFF
--- a/syntaxes/zig.tmLanguage.json
+++ b/syntaxes/zig.tmLanguage.json
@@ -192,7 +192,7 @@
         },
         {
           "name": "keyword.operator.bitwise.zig",
-          "match": "(<<%?|>>|!|&|\\^|\\|)=?"
+          "match": "(<<%?|>>|!|~|&|\\^|\\|)=?"
         },
         {
           "name": "keyword.operator.special.zig",


### PR DESCRIPTION
Pretty sure this is the correct place to change, but unfortunately can't test it locally as my npm and node versions are really old