### PR TITLE
improve formatting integration

### DIFF
--- a/package.json
+++ b/package.json
@@ -132,7 +132,7 @@
             "Provide formatting by directly invoking `zig fmt`",
             "Provide formatting by using ZLS (which matches `zig fmt`)"
           ],
-          "default": "extension"
+          "default": "zls"
         },
         "zig.zls.debugLog": {
           "scope": "resource",

--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
         "zig.formattingProvider": {
           "scope": "resource",
           "type": "string",
-          "description": "Whether to enable formatting (requires restarting editor)",
+          "description": "Whether to enable formatting",
           "enum": [
             "off",
             "extension",
@@ -129,8 +129,8 @@
           ],
           "enumDescriptions": [
             "Disable formatting",
-            "Use extension formatting",
-            "Use ZLS formatting (not recommended as zls's formatting is slower)"
+            "Provide formatting by directly invoking `zig fmt`",
+            "Provide formatting by using ZLS (which matches `zig fmt`)"
           ],
           "default": "extension"
         },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,25 +1,16 @@
 import vscode from "vscode";
 
-import { ZigFormatProvider, ZigRangeFormatProvider } from "./zigFormat";
 import { activate as activateZls, deactivate as deactivateZls } from "./zls";
 import ZigCompilerProvider from "./zigCompilerProvider";
+import { registerDocumentFormatting } from "./zigFormat";
 import { setupZig } from "./zigSetup";
-
-const ZIG_MODE: vscode.DocumentFilter = { language: "zig", scheme: "file" };
 
 export async function activate(context: vscode.ExtensionContext) {
     await setupZig(context).finally(() => {
         const compiler = new ZigCompilerProvider();
         compiler.activate(context.subscriptions);
 
-        if (vscode.workspace.getConfiguration("zig").get<string>("formattingProvider") === "extension") {
-            context.subscriptions.push(
-                vscode.languages.registerDocumentFormattingEditProvider(ZIG_MODE, new ZigFormatProvider()),
-            );
-            context.subscriptions.push(
-                vscode.languages.registerDocumentRangeFormattingEditProvider(ZIG_MODE, new ZigRangeFormatProvider()),
-            );
-        }
+        context.subscriptions.push(registerDocumentFormatting());
 
         void activateZls(context);
     });

--- a/src/zls.ts
+++ b/src/zls.ts
@@ -31,7 +31,10 @@ import {
 let outputChannel: vscode.OutputChannel;
 export let client: LanguageClient | null = null;
 
-const ZIG_MODE: DocumentSelector = [{ language: "zig", scheme: "file" }];
+const ZIG_MODE: DocumentSelector = [
+    { language: "zig", scheme: "file" },
+    { language: "zig", scheme: "untitled" },
+];
 
 async function startClient() {
     const configuration = vscode.workspace.getConfiguration("zig.zls");

--- a/src/zls.ts
+++ b/src/zls.ts
@@ -5,6 +5,7 @@ import fs from "fs";
 import {
     CancellationToken,
     ConfigurationParams,
+    DocumentSelector,
     LSPAny,
     LanguageClient,
     LanguageClientOptions,
@@ -30,6 +31,8 @@ import {
 let outputChannel: vscode.OutputChannel;
 export let client: LanguageClient | null = null;
 
+const ZIG_MODE: DocumentSelector = [{ language: "zig", scheme: "file" }];
+
 async function startClient() {
     const configuration = vscode.workspace.getConfiguration("zig.zls");
     const debugLog = configuration.get<boolean>("debugLog", false);
@@ -43,7 +46,7 @@ async function startClient() {
 
     // Options to control the language client
     const clientOptions: LanguageClientOptions = {
-        documentSelector: [{ scheme: "file", language: "zig" }],
+        documentSelector: ZIG_MODE,
         outputChannel,
         middleware: {
             workspace: {
@@ -329,7 +332,7 @@ async function installVersion(context: vscode.ExtensionContext, version: semver.
                 }
                 throw err;
             }
-            
+
             await stopClient();
 
             const installDir = vscode.Uri.joinPath(context.globalStorageUri, "zls_install");
@@ -405,6 +408,14 @@ export async function activate(context: vscode.ExtensionContext) {
                 const zlsConfig = vscode.workspace.getConfiguration("zig.zls");
                 if (zlsConfig.get<string>("path")) {
                     await startClient();
+                }
+            }
+            if (client && change.affectsConfiguration("zig.formattingProvider", undefined)) {
+                client.getFeature("textDocument/formatting").dispose();
+                if (vscode.workspace.getConfiguration("zig").get<string>("formattingProvider") === "zls") {
+                    client
+                        .getFeature("textDocument/formatting")
+                        .initialize(client.initializeResult?.capabilities ?? {}, ZIG_MODE);
                 }
             }
         }),


### PR DESCRIPTION
Over time, I've see users report issues with code formatting provided by this extension. 
Unfortunately, I have not been able to reproduce any of these issues. They may just be caused by the fact that `zig fmt` is JIT compiled or something unrelated to that.

These changes should (hopefully) make code formatting more reliable by applying the following changes:
- compile `zig fmt` when starting the extension
- make the code formatting provider async and cancel-able

I also changed the default formatting provider from `extension` to `zls`. I've made sure that formatting can fallback to the extension provider if ZLS is not running. Perhaps this makes the `formattingProvider` unnecessary all together but I will leave that to another time.