### PR TITLE
fix activation event when the workspace contains a build.zig

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,8 +17,8 @@
     "Programming Languages"
   ],
   "activationEvents": [
-    "workspaceContains:*/build.zig",
-    "workspaceContains:*/build.zig.zon"
+    "workspaceContains:build.zig",
+    "workspaceContains:build.zig.zon"
   ],
   "main": "./out/extension",
   "contributes": {


### PR DESCRIPTION
The glob pattern `*/build.zig` means that the extension gets activated iff a subfolder contains a `build.zig`. Obviously we want to look in the root folder so the pattern `build.zig` should be used.