### PR TITLE
introduce a fully featured version manager

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -1,8 +1,11 @@
+.github/**
 .vscode/**
 .vscode-test/**
 out/test/**
 src/**
 .gitignore
+.prettierignore
+eslint.config.mjs
 **/tsconfig.json
 **/tslint.json
 **/*.map

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,12 +11,14 @@
       "dependencies": {
         "axios": "^1.7.4",
         "camelcase": "^7.0.1",
+        "libsodium-wrappers": "^0.7.15",
         "lodash-es": "^4.17.21",
         "semver": "^7.5.2",
         "vscode-languageclient": "8.0.2-next.5",
         "which": "^3.0.0"
       },
       "devDependencies": {
+        "@types/libsodium-wrappers": "^0.7.14",
         "@types/lodash-es": "^4.17.12",
         "@types/mocha": "^2.2.48",
         "@types/node": "^18.0.0",
@@ -182,6 +184,13 @@
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true
+    },
+    "node_modules/@types/libsodium-wrappers": {
+      "version": "0.7.14",
+      "resolved": "https://registry.npmjs.org/@types/libsodium-wrappers/-/libsodium-wrappers-0.7.14.tgz",
+      "integrity": "sha512-5Kv68fXuXK0iDuUir1WPGw2R9fOZUlYlSAa0ztMcL0s0BfIDTqg9GXz8K30VJpPP3sxWhbolnQma2x+/TfkzDQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/lodash": {
       "version": "4.17.0",
@@ -2037,6 +2046,21 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/libsodium": {
+      "version": "0.7.15",
+      "resolved": "https://registry.npmjs.org/libsodium/-/libsodium-0.7.15.tgz",
+      "integrity": "sha512-sZwRknt/tUpE2AwzHq3jEyUU5uvIZHtSssktXq7owd++3CSgn8RGrv6UZJJBpP7+iBghBqe7Z06/2M31rI2NKw==",
+      "license": "ISC"
+    },
+    "node_modules/libsodium-wrappers": {
+      "version": "0.7.15",
+      "resolved": "https://registry.npmjs.org/libsodium-wrappers/-/libsodium-wrappers-0.7.15.tgz",
+      "integrity": "sha512-E4anqJQwcfiC6+Yrl01C1m8p99wEhLmJSs0VQqST66SbQXXBoaJY0pF4BNjRYa/sOQAxx6lXAaAFIlx+15tXJQ==",
+      "license": "ISC",
+      "dependencies": {
+        "libsodium": "^0.7.15"
       }
     },
     "node_modules/lie": {

--- a/package.json
+++ b/package.json
@@ -100,7 +100,12 @@
         "zig.path": {
           "scope": "machine-overridable",
           "type": "string",
-          "description": "Set a custom path to the Zig binary. The string \"zig\" means lookup zig in PATH."
+          "description": "Set a custom path to the `zig` executable. Example: `C:/zig-windows-x86_64-0.13.0/zig.exe`. The string \"zig\" means lookup zig in PATH."
+        },
+        "zig.version": {
+          "scope": "resource",
+          "type": "string",
+          "description": "Specify which Zig version should be installed. Takes priority over a `.zigversion` file or a `build.zig.zon` with `minimum_zig_version`."
         },
         "zig.formattingProvider": {
           "scope": "resource",

--- a/package.json
+++ b/package.json
@@ -68,11 +68,6 @@
       "type": "object",
       "title": "Zig",
       "properties": {
-        "zig.initialSetupDone": {
-          "type": "boolean",
-          "default": false,
-          "description": "Has the initial setup been done yet?"
-        },
         "zig.buildOnSave": {
           "type": "boolean",
           "default": false,

--- a/package.json
+++ b/package.json
@@ -36,6 +36,9 @@
           ".zig",
           ".zon"
         ],
+        "aliases": [
+          "Zig"
+        ],
         "configuration": "./language-configuration.json"
       }
     ],

--- a/package.json
+++ b/package.json
@@ -368,23 +368,25 @@
     "lint": "eslint ."
   },
   "devDependencies": {
+    "@types/libsodium-wrappers": "^0.7.14",
     "@types/lodash-es": "^4.17.12",
     "@types/mocha": "^2.2.48",
     "@types/node": "^18.0.0",
     "@types/vscode": "^1.80.0",
     "@types/which": "^2.0.1",
+    "@vscode/test-electron": "^2.3.9",
     "@vscode/vsce": "^2.24.0",
     "esbuild": "^0.12.1",
     "eslint": "^8.57.0",
     "eslint-config-prettier": "^9.1.0",
     "prettier": "3.2.5",
     "typescript": "^5.4.3",
-    "typescript-eslint": "^7.4.0",
-    "@vscode/test-electron": "^2.3.9"
+    "typescript-eslint": "^7.4.0"
   },
   "dependencies": {
     "axios": "^1.7.4",
     "camelcase": "^7.0.1",
+    "libsodium-wrappers": "^0.7.15",
     "lodash-es": "^4.17.21",
     "semver": "^7.5.2",
     "vscode-languageclient": "8.0.2-next.5",

--- a/package.json
+++ b/package.json
@@ -107,12 +107,6 @@
           "type": "string",
           "description": "Set a custom path to the Zig binary. The string \"zig\" means lookup zig in PATH."
         },
-        "zig.checkForUpdate": {
-          "scope": "resource",
-          "type": "boolean",
-          "description": "Whether to automatically check for new updates",
-          "default": true
-        },
         "zig.formattingProvider": {
           "scope": "resource",
           "type": "string",
@@ -338,11 +332,6 @@
       {
         "command": "zig.install",
         "title": "Install Zig",
-        "category": "Zig Setup"
-      },
-      {
-        "command": "zig.update",
-        "title": "Check for Zig Updates",
         "category": "Zig Setup"
       },
       {

--- a/package.json
+++ b/package.json
@@ -150,16 +150,21 @@
           ],
           "default": "off"
         },
-        "zig.zls.checkForUpdate": {
+        "zig.zls.enabled": {
           "scope": "resource",
-          "type": "boolean",
-          "description": "Whether to automatically check for new updates",
-          "default": true
+          "type": "string",
+          "description": "Whether to enable the optional ZLS Language Server",
+          "enum": [
+            "ask",
+            "off",
+            "on"
+          ],
+          "default": "ask"
         },
         "zig.zls.path": {
           "scope": "machine-overridable",
           "type": "string",
-          "description": "Path to `zls` executable. Example: `C:/zls/zig-cache/bin/zls.exe`. The string \"zls\" means lookup ZLS in PATH.",
+          "description": "Set a custom path to the `zls` executable. Example: `C:/zls/zig-cache/bin/zls.exe`. The string \"zls\" means lookup ZLS in PATH.",
           "format": "path"
         },
         "zig.zls.enableSnippets": {
@@ -341,23 +346,18 @@
         "category": "Zig Setup"
       },
       {
-        "command": "zig.zls.install",
-        "title": "Install Server",
+        "command": "zig.zls.enable",
+        "title": "Enable Language Server",
         "category": "Zig Language Server"
       },
       {
         "command": "zig.zls.startRestart",
-        "title": "Start / Restart Server",
+        "title": "Start / Restart Language Server",
         "category": "Zig Language Server"
       },
       {
         "command": "zig.zls.stop",
-        "title": "Stop Server",
-        "category": "Zig Language Server"
-      },
-      {
-        "command": "zig.zls.update",
-        "title": "Check for Server Updates",
+        "title": "Stop Language Server",
         "category": "Zig Language Server"
       }
     ],

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,7 +1,7 @@
 import vscode from "vscode";
 
 import { activate as activateZls, deactivate as deactivateZls } from "./zls";
-import ZigCompilerProvider from "./zigCompilerProvider";
+import ZigDiagnosticsProvider from "./zigDiagnosticsProvider";
 import ZigMainCodeLensProvider from "./zigMainCodeLens";
 import ZigTestRunnerProvider from "./zigTestRunnerProvider";
 import { registerDocumentFormatting } from "./zigFormat";
@@ -9,7 +9,7 @@ import { setupZig } from "./zigSetup";
 
 export async function activate(context: vscode.ExtensionContext) {
     await setupZig(context).finally(() => {
-        const compiler = new ZigCompilerProvider();
+        const compiler = new ZigDiagnosticsProvider();
         compiler.activate(context.subscriptions);
 
         context.subscriptions.push(registerDocumentFormatting());

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,11 +1,11 @@
 import vscode from "vscode";
 
 import { activate as activateZls, deactivate as deactivateZls } from "./zls";
+import { deactivate as deactivateSetupZig, setupZig } from "./zigSetup";
 import ZigDiagnosticsProvider from "./zigDiagnosticsProvider";
 import ZigMainCodeLensProvider from "./zigMainCodeLens";
 import ZigTestRunnerProvider from "./zigTestRunnerProvider";
 import { registerDocumentFormatting } from "./zigFormat";
-import { setupZig } from "./zigSetup";
 
 export async function activate(context: vscode.ExtensionContext) {
     await setupZig(context).finally(() => {
@@ -31,4 +31,5 @@ export async function activate(context: vscode.ExtensionContext) {
 
 export async function deactivate() {
     await deactivateZls();
+    await deactivateSetupZig();
 }

--- a/src/minisign.ts
+++ b/src/minisign.ts
@@ -1,0 +1,92 @@
+/**
+ * Ported from: https://github.com/mlugg/setup-zig/blob/main/main.js (MIT)
+ */
+
+import sodium from "libsodium-wrappers";
+
+export interface Key {
+    id: Buffer;
+    key: Buffer;
+}
+
+// Parse a minisign key represented as a base64 string.
+// Throws exceptions on invalid keys.
+export function parseKey(keyString: string): Key {
+    const keyInfo = Buffer.from(keyString, "base64");
+
+    const id = keyInfo.subarray(2, 10);
+    const key = keyInfo.subarray(10);
+
+    if (key.byteLength !== sodium.crypto_sign_PUBLICKEYBYTES) {
+        throw new Error("invalid public key given");
+    }
+
+    return {
+        id: id,
+        key: key,
+    };
+}
+
+export interface Signature {
+    algorithm: Buffer;
+    keyID: Buffer;
+    signature: Buffer;
+}
+
+// Parse a buffer containing the contents of a minisign signature file.
+// Throws exceptions on invalid signature files.
+export function parseSignature(sigBuf: Buffer): Signature {
+    const untrustedHeader = Buffer.from("untrusted comment: ");
+
+    // Validate untrusted comment header, and skip
+    if (!sigBuf.subarray(0, untrustedHeader.byteLength).equals(untrustedHeader)) {
+        throw new Error("file format not recognised");
+    }
+    sigBuf = sigBuf.subarray(untrustedHeader.byteLength);
+
+    // Skip untrusted comment
+    sigBuf = sigBuf.subarray(sigBuf.indexOf("\n") + 1);
+
+    // Read and skip signature info
+    const sigInfoEnd = sigBuf.indexOf("\n");
+    const sigInfo = Buffer.from(sigBuf.subarray(0, sigInfoEnd).toString(), "base64");
+    sigBuf = sigBuf.subarray(sigInfoEnd + 1);
+
+    // Extract components of signature info
+    const algorithm = sigInfo.subarray(0, 2);
+    const keyID = sigInfo.subarray(2, 10);
+    const signature = sigInfo.subarray(10);
+
+    // We don't look at the trusted comment or global signature, so we're done.
+
+    return {
+        algorithm: algorithm,
+        keyID: keyID,
+        signature: signature,
+    };
+}
+
+// Given a parsed key, parsed signature file, and raw file content, verifies the
+// signature. Does not throw. Returns 'true' if the signature is valid for this
+// file, 'false' otherwise.
+export function verifySignature(pubkey: Key, signature: Signature, fileContent: Buffer) {
+    let signedContent;
+    if (signature.algorithm.equals(Buffer.from("ED"))) {
+        signedContent = sodium.crypto_generichash(sodium.crypto_generichash_BYTES_MAX, fileContent);
+    } else {
+        signedContent = fileContent;
+    }
+
+    if (!signature.keyID.equals(pubkey.id)) {
+        return false;
+    }
+
+    if (!sodium.crypto_sign_verify_detached(signature.signature, signedContent, pubkey.key)) {
+        return false;
+    }
+
+    // Since we don't use the trusted comment, we don't bother verifying the global signature.
+    // If we were to start using the trusted comment for any purpose, we must add this.
+
+    return true;
+}

--- a/src/versionManager.ts
+++ b/src/versionManager.ts
@@ -168,3 +168,25 @@ async function installFromMirror(
         },
     );
 }
+
+/** Returns all locally installed versions */
+export async function query(config: Config): Promise<semver.SemVer[]> {
+    const available: semver.SemVer[] = [];
+    const prefix = `${getZigOSName()}-${getZigArchName()}`;
+
+    const storageDir = vscode.Uri.joinPath(config.context.globalStorageUri, config.exeName);
+    try {
+        for (const [name] of await vscode.workspace.fs.readDirectory(storageDir)) {
+            if (name.startsWith(prefix)) {
+                available.push(new semver.SemVer(name.substring(prefix.length + 1)));
+            }
+        }
+    } catch (e) {
+        if (e instanceof vscode.FileSystemError && e.code === "FileNotFound") {
+            return [];
+        }
+        throw e;
+    }
+
+    return available;
+}

--- a/src/versionManager.ts
+++ b/src/versionManager.ts
@@ -1,0 +1,170 @@
+/**
+ * A version manager for Zig and ZLS.
+ *
+ * Expects a provider that follows the following scheme:
+ * `${PROVIDER_URL}/${NAME}-${OS}-${ARCH}-${VERSION}.${FILE_EXTENSION}`
+ *
+ * Example:
+ *   - `https://ziglang.org/download/0.13.0/zig-windows-x86_64-0.13.0.zip`
+ *   - `https://builds.zigtools.org/zls-linux-x86_64-0.13.0.tar.xz`
+ */
+
+import vscode from "vscode";
+
+import childProcess from "child_process";
+import fs from "fs";
+import util from "util";
+import which from "which";
+
+import axios from "axios";
+import semver from "semver";
+
+import { getVersion, getZigArchName, getZigOSName } from "./zigUtil";
+
+const execFile = util.promisify(childProcess.execFile);
+const chmod = util.promisify(fs.chmod);
+
+export interface Config {
+    context: vscode.ExtensionContext;
+    /** The name of the application. */
+    title: string;
+    /** The name of the executable file. */
+    exeName: string;
+    /** The command-line argument that should passed to `tar` to exact the tarball. */
+    extraTarArgs: string[];
+    /**
+     * The command-line argument that should passed to the executable to query the version.
+     * `"version"` for Zig, `"--version"` for ZLS
+     */
+    versionArg: string;
+    canonicalUrl: {
+        release: vscode.Uri;
+        nightly: vscode.Uri;
+    };
+}
+
+/** Returns the path to the executable */
+export async function install(config: Config, version: semver.SemVer): Promise<string> {
+    const exeName = config.exeName + (process.platform === "win32" ? ".exe" : "");
+    const subDirName = `${getZigOSName()}-${getZigArchName()}-${version.raw}`;
+    const exeUri = vscode.Uri.joinPath(config.context.globalStorageUri, config.exeName, subDirName, exeName);
+
+    try {
+        await vscode.workspace.fs.stat(exeUri);
+        return exeUri.fsPath;
+    } catch (e) {
+        if (e instanceof vscode.FileSystemError) {
+            if (e.code !== "FileNotFound") {
+                throw e;
+            }
+            // go ahead an install
+        } else {
+            throw e;
+        }
+    }
+
+    const canonicalUrl = version.prerelease.length === 0 ? config.canonicalUrl.release : config.canonicalUrl.nightly;
+    const mirrorName = new URL(canonicalUrl.toString()).host;
+    return await installFromMirror(config, version, canonicalUrl, mirrorName);
+}
+
+/** Returns the path to the executable */
+async function installFromMirror(
+    config: Config,
+    version: semver.SemVer,
+    mirrorUrl: vscode.Uri,
+    mirrorName: string,
+): Promise<string> {
+    const isWindows = process.platform === "win32";
+    const fileExtension = isWindows ? "zip" : "tar.xz";
+    const exeName = config.exeName + (isWindows ? ".exe" : "");
+    const subDirName = `${getZigOSName()}-${getZigArchName()}-${version.raw}`;
+    const fileName = `${config.exeName}-${subDirName}.${fileExtension}`;
+
+    const installDir = vscode.Uri.joinPath(config.context.globalStorageUri, config.exeName, subDirName);
+    const exeUri = vscode.Uri.joinPath(installDir, exeName);
+    const tarballUri = vscode.Uri.joinPath(installDir, fileName);
+
+    const tarPath = await which("tar", { nothrow: true });
+    if (!tarPath) {
+        throw new Error(`Downloaded ${config.title} tarball can't be extracted because 'tar' could not be found`);
+    }
+
+    return await vscode.window.withProgress<string>(
+        {
+            title: `Installing ${config.title} from ${mirrorName}`,
+            location: vscode.ProgressLocation.Notification,
+        },
+        async (progress, cancelToken) => {
+            const abortController = new AbortController();
+            cancelToken.onCancellationRequested(() => {
+                abortController.abort();
+            });
+
+            const artifactUrl = vscode.Uri.joinPath(mirrorUrl, fileName);
+            /** https://github.com/mlugg/setup-zig adds a `?source=github-actions` query parameter so we add our own.  */
+            const artifactUrlWithQuery = artifactUrl.with({ query: "source=vscode-zig" });
+
+            const artifactResponse = await axios.get<Buffer>(artifactUrlWithQuery.toString(), {
+                responseType: "arraybuffer",
+                signal: abortController.signal,
+                onDownloadProgress: (progressEvent) => {
+                    if (progressEvent.total) {
+                        const increment = (progressEvent.bytes / progressEvent.total) * 100;
+                        progress.report({
+                            message: progressEvent.progress
+                                ? `downloading tarball ${(progressEvent.progress * 100).toFixed()}%`
+                                : "downloading tarball...",
+                            increment: increment,
+                        });
+                    }
+                },
+            });
+            const artifactData = Buffer.from(artifactResponse.data);
+
+            try {
+                await vscode.workspace.fs.delete(installDir, { recursive: true, useTrash: false });
+            } catch {}
+            await vscode.workspace.fs.createDirectory(installDir);
+            await vscode.workspace.fs.writeFile(tarballUri, new Uint8Array(artifactData));
+
+            progress.report({ message: "Extracting..." });
+            try {
+                await execFile(
+                    tarPath,
+                    ["-xf", tarballUri.fsPath, "-C", installDir.fsPath].concat(config.extraTarArgs),
+                    {
+                        signal: abortController.signal,
+                        timeout: 60000, // 60 seconds
+                    },
+                );
+            } catch (err) {
+                try {
+                    await vscode.workspace.fs.delete(installDir, { recursive: true, useTrash: false });
+                } catch {}
+                if (err instanceof Error) {
+                    throw new Error(`Failed to extract ${config.title} tarball: ${err.message}`);
+                } else {
+                    throw err;
+                }
+            } finally {
+                try {
+                    await vscode.workspace.fs.delete(tarballUri, { useTrash: false });
+                } catch {}
+            }
+
+            const exeVersion = getVersion(exeUri.fsPath, config.versionArg);
+            if (!exeVersion || exeVersion.compare(version) !== 0) {
+                try {
+                    await vscode.workspace.fs.delete(installDir, { recursive: true, useTrash: false });
+                } catch {}
+                // a mirror may provide the wrong version
+                throw new Error(`Failed to validate version of ${config.title} installation!`);
+            }
+
+            await chmod(exeUri.fsPath, 0o755);
+
+            return exeUri.fsPath;
+        },
+    );
+}

--- a/src/zigDiagnosticsProvider.ts
+++ b/src/zigDiagnosticsProvider.ts
@@ -7,7 +7,8 @@ import path from "path";
 import { DebouncedFunc, throttle } from "lodash-es";
 
 import * as zls from "./zls";
-import { getZigPath, handleConfigOption } from "./zigUtil";
+import { handleConfigOption } from "./zigUtil";
+import { zigProvider } from "./zigSetup";
 
 export default class ZigDiagnosticsProvider {
     private buildDiagnostics!: vscode.DiagnosticCollection;
@@ -89,7 +90,8 @@ export default class ZigDiagnosticsProvider {
         if (textDocument.languageId !== "zig") {
             return;
         }
-        const zigPath = getZigPath();
+        const zigPath = zigProvider.getZigPath();
+        if (!zigPath) return null;
         const { error, stderr } = childProcess.spawnSync(zigPath, ["ast-check"], {
             input: textDocument.getText(),
             maxBuffer: 10 * 1024 * 1024, // 10MB
@@ -134,7 +136,8 @@ export default class ZigDiagnosticsProvider {
     private _doCompile(textDocument: vscode.TextDocument) {
         const config = vscode.workspace.getConfiguration("zig");
 
-        const zigPath = getZigPath();
+        const zigPath = zigProvider.getZigPath();
+        if (!zigPath) return null;
 
         const buildOption = config.get<string>("buildOption", "build");
         const processArg: string[] = [buildOption];

--- a/src/zigDiagnosticsProvider.ts
+++ b/src/zigDiagnosticsProvider.ts
@@ -9,7 +9,7 @@ import { DebouncedFunc, throttle } from "lodash-es";
 import * as zls from "./zls";
 import { getZigPath, handleConfigOption } from "./zigUtil";
 
-export default class ZigCompilerProvider {
+export default class ZigDiagnosticsProvider {
     private buildDiagnostics!: vscode.DiagnosticCollection;
     private astDiagnostics!: vscode.DiagnosticCollection;
     private dirtyChange = new WeakMap<vscode.Uri, boolean>();

--- a/src/zigProvider.ts
+++ b/src/zigProvider.ts
@@ -1,0 +1,66 @@
+import vscode from "vscode";
+
+import semver from "semver";
+
+import { resolveExePathAndVersion } from "./zigUtil";
+
+interface ExeWithVersion {
+    exe: string;
+    version: semver.SemVer;
+}
+
+export class ZigProvider implements vscode.Disposable {
+    onChange: vscode.EventEmitter<ExeWithVersion | null> = new vscode.EventEmitter();
+    private value: ExeWithVersion | null;
+    private disposables: vscode.Disposable[];
+
+    constructor() {
+        this.value = this.resolveZigPathConfigOption();
+        this.disposables = [
+            vscode.workspace.onDidChangeConfiguration((change) => {
+                if (change.affectsConfiguration("zig.path")) {
+                    const newValue = this.resolveZigPathConfigOption();
+                    if (newValue) {
+                        this.value = newValue;
+                        this.set(this.value);
+                    }
+                }
+            }),
+        ];
+    }
+
+    /** Returns the version of the Zig executable that is currently being used. */
+    public getZigVersion(): semver.SemVer | null {
+        return this.value?.version ?? null;
+    }
+
+    /** Returns the path to the Zig executable that is currently being used. */
+    public getZigPath(): string | null {
+        return this.value?.exe ?? null;
+    }
+
+    /** Override which zig executable should be used. The `zig.path` config option will be ignored */
+    public set(value: ExeWithVersion | null) {
+        this.value = value;
+        this.onChange.fire(value);
+    }
+
+    /** Resolves the `zig.path` configuration option */
+    private resolveZigPathConfigOption(): ExeWithVersion | null {
+        const zigPath = vscode.workspace.getConfiguration("zig").get<string>("path", "");
+        if (!zigPath) return null;
+        const exePath = zigPath !== "zig" ? zigPath : null; // the string "zig" means lookup in PATH
+        const result = resolveExePathAndVersion(exePath, "zig", "zig.path", "version");
+        if ("message" in result) {
+            void vscode.window.showErrorMessage(`'zig.path' is not valid: ${result.message}`);
+            return null;
+        }
+        return result;
+    }
+
+    dispose() {
+        for (const disposable of this.disposables) {
+            disposable.dispose();
+        }
+    }
+}

--- a/src/zigSetup.ts
+++ b/src/zigSetup.ts
@@ -386,6 +386,14 @@ export async function setupZig(context: vscode.ExtensionContext) {
         /** https://ziglang.org/download */
         minisignKey: minisign.parseKey("RWSGOq2NVecA2UPNdBUZykf1CCb147pkmdtYxgb3Ti+JO/wCYvhbAb/U"),
         versionArg: "version",
+        // taken from https://github.com/mlugg/setup-zig/blob/main/mirrors.json
+        mirrorUrls: [
+            vscode.Uri.parse("https://pkg.machengine.org/zig"),
+            vscode.Uri.parse("https://zigmirror.hryx.net/zig"),
+            vscode.Uri.parse("https://zig.linus.dev/zig"),
+            vscode.Uri.parse("https://fs.liujiacai.net/zigbuilds"),
+            vscode.Uri.parse("https://zigmirror.nesovic.dev/zig"),
+        ],
         canonicalUrl: {
             release: vscode.Uri.parse("https://ziglang.org/download"),
             nightly: vscode.Uri.parse("https://ziglang.org/builds"),

--- a/src/zigSetup.ts
+++ b/src/zigSetup.ts
@@ -452,3 +452,7 @@ export async function setupZig(context: vscode.ExtensionContext) {
 
     await refreshZigInstallation();
 }
+
+export async function deactivate() {
+    await versionManager.removeUnusedInstallations(versionManagerConfig);
+}

--- a/src/zigSetup.ts
+++ b/src/zigSetup.ts
@@ -416,6 +416,8 @@ export async function setupZig(context: vscode.ExtensionContext) {
         if (zigPath.startsWith(context.globalStorageUri.fsPath)) {
             await zigConfig.update("path", undefined, true);
         }
+
+        await zigConfig.update("initialSetupDone", undefined, true);
     }
 
     versionManagerConfig = {

--- a/src/zigSetup.ts
+++ b/src/zigSetup.ts
@@ -5,27 +5,15 @@ import semver from "semver";
 import vscode from "vscode";
 
 import * as versionManager from "./versionManager";
-import { getHostZigName, getVersion, getZigPath, shouldCheckUpdate } from "./zigUtil";
+import { VersionIndex, ZigVersion, getHostZigName, getVersion, getZigPath, shouldCheckUpdate } from "./zigUtil";
 import { restartClient } from "./zls";
 
 let versionManagerConfig: versionManager.Config;
-
-const DOWNLOAD_INDEX = "https://ziglang.org/download/index.json";
 
 function getNightlySemVer(url: string): string {
     const matches = url.match(/-(\d+\.\d+\.\d+(-dev\.\d+\+\w+)?)\./);
     if (!matches) throw new Error(`url '${url}' does not contain a semantic version!`);
     return matches[1];
-}
-
-type VersionIndex = Record<string, Record<string, undefined | { tarball: string; shasum: string; size: string }>>;
-
-interface ZigVersion {
-    name: string;
-    url: string;
-    sha: string;
-    notes?: string;
-    version: semver.SemVer;
 }
 
 export async function installZig(context: vscode.ExtensionContext, version: semver.SemVer) {
@@ -42,8 +30,8 @@ export async function installZig(context: vscode.ExtensionContext, version: semv
 }
 
 async function getVersions(): Promise<ZigVersion[]> {
+    const indexJson = (await axios.get<VersionIndex>("https://ziglang.org/download/index.json", {})).data;
     const hostName = getHostZigName();
-    const indexJson = (await axios.get<VersionIndex>(DOWNLOAD_INDEX, {})).data;
     const result: ZigVersion[] = [];
     for (let key in indexJson) {
         const value = indexJson[key];

--- a/src/zigSetup.ts
+++ b/src/zigSetup.ts
@@ -370,6 +370,14 @@ export async function setupZig(context: vscode.ExtensionContext) {
     {
         // This check can be removed once enough time has passed so that most users switched to the new value
 
+        // remove the `zig_install` directory from the global storage
+        try {
+            await vscode.workspace.fs.delete(vscode.Uri.joinPath(context.globalStorageUri, "zig_install"), {
+                recursive: true,
+                useTrash: false,
+            });
+        } catch {}
+
         // remove a `zig.path` that points to the global storage.
         const zigConfig = vscode.workspace.getConfiguration("zig");
         const zigPath = zigConfig.get<string>("path", "");

--- a/src/zigSetup.ts
+++ b/src/zigSetup.ts
@@ -356,8 +356,8 @@ async function getWantedZigVersion(
 }
 
 function updateStatusItem(item: vscode.StatusBarItem, version: semver.SemVer | null) {
-    item.name = "Zig";
-    item.text = `Zig ${version?.toString() ?? "not installed"}`;
+    item.name = "Zig Version";
+    item.text = version?.toString() ?? "not installed";
     item.tooltip = "Select Zig Version";
     item.command = {
         title: "Select Version",

--- a/src/zigSetup.ts
+++ b/src/zigSetup.ts
@@ -5,6 +5,7 @@ import path from "path";
 import axios from "axios";
 import semver from "semver";
 
+import * as minisign from "./minisign";
 import * as versionManager from "./versionManager";
 import { VersionIndex, ZigVersion, getHostZigName, resolveExePathAndVersion } from "./zigUtil";
 import { ZigProvider } from "./zigProvider";
@@ -382,6 +383,8 @@ export async function setupZig(context: vscode.ExtensionContext) {
         title: "Zig",
         exeName: "zig",
         extraTarArgs: ["--strip-components=1"],
+        /** https://ziglang.org/download */
+        minisignKey: minisign.parseKey("RWSGOq2NVecA2UPNdBUZykf1CCb147pkmdtYxgb3Ti+JO/wCYvhbAb/U"),
         versionArg: "version",
         canonicalUrl: {
             release: vscode.Uri.parse("https://ziglang.org/download"),

--- a/src/zigUtil.ts
+++ b/src/zigUtil.ts
@@ -173,11 +173,15 @@ export interface ZigVersion {
     url: string;
     sha: string;
     notes?: string;
+    isMach: boolean;
 }
 
 export type VersionIndex = Record<
     string,
-    Record<string, undefined | { tarball: string; shasum: string; size: string }>
+    {
+        version?: string;
+        notes?: string;
+    } & Record<string, undefined | { tarball: string; shasum: string; size: string }>
 >;
 
 export function getWorkspaceFolder(filePath: string): vscode.WorkspaceFolder | undefined {

--- a/src/zigUtil.ts
+++ b/src/zigUtil.ts
@@ -143,6 +143,19 @@ export function getVersion(filePath: string, arg: string): semver.SemVer | null 
     }
 }
 
+export interface ZigVersion {
+    name: string;
+    version: semver.SemVer;
+    url: string;
+    sha: string;
+    notes?: string;
+}
+
+export type VersionIndex = Record<
+    string,
+    Record<string, undefined | { tarball: string; shasum: string; size: string }>
+>;
+
 export function getWorkspaceFolder(filePath: string): vscode.WorkspaceFolder | undefined {
     const workspaceFolder = vscode.workspace.getWorkspaceFolder(vscode.Uri.file(filePath));
     if (!workspaceFolder && vscode.workspace.workspaceFolders && vscode.workspace.workspaceFolders.length > 0) {

--- a/src/zigUtil.ts
+++ b/src/zigUtil.ts
@@ -1,19 +1,12 @@
 import vscode from "vscode";
 
 import childProcess from "child_process";
-import crypto from "crypto";
 import fs from "fs";
 import os from "os";
 import path from "path";
-import { promisify } from "util";
 
-import assert from "assert";
-import axios from "axios";
 import semver from "semver";
 import which from "which";
-
-const execFile = promisify(childProcess.execFile);
-const chmod = promisify(fs.chmod);
 
 // Replace any references to predefined variables in config string.
 // https://code.visualstudio.com/docs/editor/variables-reference#_predefined-variables
@@ -103,18 +96,37 @@ export async function shouldCheckUpdate(context: vscode.ExtensionContext, key: s
     return true;
 }
 
+export function getZigArchName(): string {
+    switch (process.arch) {
+        case "ia32":
+            return "x86";
+        case "x64":
+            return "x86_64";
+        case "arm":
+            return "armv7a";
+        case "arm64":
+            return "aarch64";
+        case "ppc":
+            return "powerpc";
+        case "ppc64":
+            return "powerpc64le";
+        default:
+            return process.arch;
+    }
+}
+export function getZigOSName(): string {
+    switch (process.platform) {
+        case "darwin":
+            return "macos";
+        case "win32":
+            return "windows";
+        default:
+            return process.platform;
+    }
+}
+
 export function getHostZigName(): string {
-    let platform: string = process.platform;
-    if (platform === "darwin") platform = "macos";
-    if (platform === "win32") platform = "windows";
-    let arch: string = process.arch;
-    if (arch === "ia32") arch = "x86";
-    if (arch === "x64") arch = "x86_64";
-    if (arch === "arm") arch = "armv7a";
-    if (arch === "arm64") arch = "aarch64";
-    if (arch === "ppc") arch = "powerpc";
-    if (arch === "ppc64") arch = "powerpc64le";
-    return `${arch}-${platform}`;
+    return `${getZigArchName()}-${getZigOSName()}`;
 }
 
 export function getVersion(filePath: string, arg: string): semver.SemVer | null {
@@ -129,93 +141,6 @@ export function getVersion(filePath: string, arg: string): semver.SemVer | null 
     } catch {
         return null;
     }
-}
-
-export async function downloadAndExtractArtifact(
-    /** e.g. `Zig` or `ZLS` */
-    title: string,
-    /** e.g. `zig` or `zls` */
-    executableName: string,
-    /** e.g. inside `context.globalStorageUri` */
-    installDir: vscode.Uri,
-    artifactUrl: string,
-    /** The expected sha256 hash (in hex) of the artifact/tarball. */
-    sha256: string,
-    /** Extract arguments that should be passed to `tar`. e.g. `--strip-components=1` */
-    extraTarArgs: string[],
-): Promise<string | null> {
-    assert.strictEqual(sha256.length, 64);
-
-    return await vscode.window.withProgress<string | null>(
-        {
-            title: `Installing ${title}`,
-            location: vscode.ProgressLocation.Notification,
-        },
-        async (progress) => {
-            progress.report({ message: `downloading ${title} tarball...` });
-            const response = await axios.get<Buffer>(artifactUrl, {
-                responseType: "arraybuffer",
-                onDownloadProgress: (progressEvent) => {
-                    if (progressEvent.total) {
-                        const increment = (progressEvent.bytes / progressEvent.total) * 100;
-                        progress.report({
-                            message: progressEvent.progress
-                                ? `downloading tarball ${(progressEvent.progress * 100).toFixed()}%`
-                                : "downloading tarball...",
-                            increment: increment,
-                        });
-                    }
-                },
-            });
-            const tarHash = crypto.createHash("sha256").update(response.data).digest("hex");
-            if (tarHash !== sha256) {
-                throw Error(`hash of downloaded tarball ${tarHash} does not match expected hash ${sha256}`);
-            }
-
-            const tarPath = await which("tar", { nothrow: true });
-            if (!tarPath) {
-                void vscode.window.showErrorMessage(
-                    `Downloaded ${title} tarball can't be extracted because 'tar' could not be found`,
-                );
-                return null;
-            }
-
-            const tarballUri = vscode.Uri.joinPath(installDir, path.basename(artifactUrl));
-
-            try {
-                await vscode.workspace.fs.delete(installDir, { recursive: true, useTrash: false });
-            } catch {}
-            await vscode.workspace.fs.createDirectory(installDir);
-            await vscode.workspace.fs.writeFile(tarballUri, response.data);
-
-            progress.report({ message: "Extracting..." });
-            try {
-                await execFile(tarPath, ["-xf", tarballUri.fsPath, "-C", installDir.fsPath].concat(extraTarArgs), {
-                    timeout: 60000, // 60 seconds
-                });
-            } catch (err) {
-                if (err instanceof Error) {
-                    void vscode.window.showErrorMessage(`Failed to extract ${title} tarball: ${err.message}`);
-                } else {
-                    throw err;
-                }
-                return null;
-            } finally {
-                try {
-                    await vscode.workspace.fs.delete(tarballUri, { useTrash: false });
-                } catch {}
-            }
-
-            progress.report({ message: "Installing..." });
-
-            const isWindows = process.platform === "win32";
-            const exeName = `${executableName}${isWindows ? ".exe" : ""}`;
-            const exePath = vscode.Uri.joinPath(installDir, exeName).fsPath;
-            await chmod(exePath, 0o755);
-
-            return exePath;
-        },
-    );
 }
 
 export function getWorkspaceFolder(filePath: string): vscode.WorkspaceFolder | undefined {

--- a/src/zls.ts
+++ b/src/zls.ts
@@ -227,7 +227,7 @@ async function configurationMiddleware(
 }
 
 /**
- * Similar to https://ziglang.org/download/index.json
+ * Similar to https://builds.zigtools.org/index.json
  */
 interface SelectVersionResponse {
     /** The ZLS version */
@@ -396,6 +396,7 @@ export async function activate(context: vscode.ExtensionContext) {
         /** https://github.com/zigtools/release-worker */
         minisignKey: minisign.parseKey("RWR+9B91GBZ0zOjh6Lr17+zKf5BoSuFvrx2xSeDE57uIYvnKBGmMjOex"),
         versionArg: "--version",
+        mirrorUrls: [],
         canonicalUrl: {
             release: vscode.Uri.parse("https://builds.zigtools.org"),
             nightly: vscode.Uri.parse("https://builds.zigtools.org"),

--- a/src/zls.ts
+++ b/src/zls.ts
@@ -448,4 +448,5 @@ export async function activate(context: vscode.ExtensionContext) {
 
 export async function deactivate(): Promise<void> {
     await stopClient();
+    await versionManager.removeUnusedInstallations(versionManagerConfig);
 }

--- a/src/zls.ts
+++ b/src/zls.ts
@@ -17,7 +17,7 @@ import semver from "semver";
 
 import * as minisign from "./minisign";
 import * as versionManager from "./versionManager";
-import { getHostZigName, getVersion, handleConfigOption, resolveExePathAndVersion } from "./zigUtil";
+import { getHostZigName, handleConfigOption, resolveExePathAndVersion } from "./zigUtil";
 import { zigProvider } from "./zigSetup";
 
 const ZIG_MODE: DocumentSelector = [
@@ -131,25 +131,6 @@ async function getZLSPath(context: vscode.ExtensionContext): Promise<{ exe: stri
             void vscode.window.showErrorMessage(`Failed to install ZLS ${result.version.toString()}!`);
         }
         return null;
-    }
-
-    /** `--version` has been added in https://github.com/zigtools/zls/pull/583 */
-    const zlsVersionArgAdded = new semver.SemVer("0.10.0-dev.150+cb5eeb0b4");
-
-    if (semver.gte(zlsVersion, zlsVersionArgAdded)) {
-        // Verify the installation by quering the version
-        const checkedZLSVersion = getVersion(zlsExePath, "--version");
-        if (!checkedZLSVersion) {
-            void vscode.window.showErrorMessage(`Unable to check ZLS version. '${zlsExePath} --version' failed!`);
-            return null;
-        }
-
-        if (checkedZLSVersion.compare(zlsVersion) !== 0) {
-            // The Matrix is broken!
-            void vscode.window.showWarningMessage(
-                `Encountered unexpected ZLS version. Expected '${zlsVersion.toString()}' from '${zlsExePath} --version' but got '${checkedZLSVersion.toString()}'!`,
-            );
-        }
     }
 
     return {

--- a/src/zls.ts
+++ b/src/zls.ts
@@ -32,20 +32,25 @@ export let client: LanguageClient | null = null;
 
 export async function restartClient(context: vscode.ExtensionContext): Promise<void> {
     const result = await getZLSPath(context);
-    updateStatusItem(result?.version ?? null);
 
-    if (!result) return;
+    if (!result) {
+        await stopClient();
+        updateStatusItem(null);
+        return;
+    }
 
     try {
         const newClient = await startClient(result.exe, result.version);
         await stopClient();
         client = newClient;
+        updateStatusItem(result.version);
     } catch (reason) {
         if (reason instanceof Error) {
             void vscode.window.showWarningMessage(`Failed to run Zig Language Server (ZLS): ${reason.message}`);
         } else {
             void vscode.window.showWarningMessage("Failed to run Zig Language Server (ZLS)");
         }
+        updateStatusItem(null);
     }
 }
 

--- a/src/zls.ts
+++ b/src/zls.ts
@@ -15,6 +15,7 @@ import axios from "axios";
 import camelCase from "camelcase";
 import semver from "semver";
 
+import * as minisign from "./minisign";
 import * as versionManager from "./versionManager";
 import { getHostZigName, getVersion, handleConfigOption, resolveExePathAndVersion } from "./zigUtil";
 import { zigProvider } from "./zigSetup";
@@ -392,6 +393,8 @@ export async function activate(context: vscode.ExtensionContext) {
         title: "ZLS",
         exeName: "zls",
         extraTarArgs: [],
+        /** https://github.com/zigtools/release-worker */
+        minisignKey: minisign.parseKey("RWR+9B91GBZ0zOjh6Lr17+zKf5BoSuFvrx2xSeDE57uIYvnKBGmMjOex"),
         versionArg: "--version",
         canonicalUrl: {
             release: vscode.Uri.parse("https://builds.zigtools.org"),

--- a/src/zls.ts
+++ b/src/zls.ts
@@ -379,6 +379,14 @@ export async function activate(context: vscode.ExtensionContext) {
     {
         // This check can be removed once enough time has passed so that most users switched to the new value
 
+        // remove the `zls_install` directory from the global storage
+        try {
+            await vscode.workspace.fs.delete(vscode.Uri.joinPath(context.globalStorageUri, "zls_install"), {
+                recursive: true,
+                useTrash: false,
+            });
+        } catch {}
+
         // convert a `zig.zls.path` that points to the global storage to `zig.zls.enabled == "on"`
         const zlsConfig = vscode.workspace.getConfiguration("zig.zls");
         const zlsPath = zlsConfig.get<string>("path", "");


### PR DESCRIPTION
Installing Zig or ZLS with the extension doesn't properly handle switching between different Zig project. 
You have to manually figure out which version to get and install it every time your switch to a project that requires a different Zig version. Same goes for ZLS. The vscode configuration for Zig also can't handle switching between devices (see #111)
Let's stop giving developer the ability to misconfigure their editor.

1. No initial setup for Zig
2. initial setup for ZLS is only 'yes' or 'no'
3. Done!

### Version Manager

This is how the extension selects which version of Zig to install:

- set the `zig.version` config option (can be global or per-workspace)
- manually set the version through the 'Select and Install' popup (per-workspace)
- set `minimum_zig_version` in the `build.zig` of your workspace
- add a `.zigversion` to your workspace which stores the desired Zig version

If none of the above apply, the latest tagged release of Zig is installed.
Installs are automatically uninstalled to not fill up disk storage too much. 
Installs are downloaded from mirrors just like [setup-zig](https://github.com/mlugg/setup-zig) (fixes #238) and verified with [minisign](https://jedisct1.github.io/minisign/) 
The version of ZLS is inferred from the Zig version.

One unfortunate limitation is that the Zig installation will fail if the exact Zig version in the `build.zig.zon` is not provided as a prebuilt binary. There is no mechanism in place that will try to find the next available version.

### Status Bar

Hovering over the "Editor Language Status" will show whether Zig and ZLS are installed + their versions. The Status Bar Item for Zig will turn red if is not installed. Clicking on it will open the 'Select and Install' popup.

![Screenshot from 2024-09-07 21-23-59](https://github.com/user-attachments/assets/6df7bd8f-7a27-432d-8b09-0283ddadb069)

### Updated 'Select and Install' popup

- added an option to manually specify the path to Zig
- added an option to select Zig from PATH (if available)
- added an option to install [Mach's Nominated Zig versions](https://machengine.org/docs/nominated-zig/#nominated-zig-history)
- display the exact version of nightly
- display which versions are already installed on the host machine
- if no network connection is available, only versions that are already installed are displayed

![Screenshot from 2024-11-22 09-38-52](https://github.com/user-attachments/assets/67bd1749-4e0e-4e07-aa0b-53bb7c777315)

### Zig version update

* The `zig.update` command has been removed. The 'Select and Install' popup can be used instead.
* The `zig.checkForUpdate` has been removed. I can open a follow-up issue about it. I can foresee this needing some extra discussion to evaluate whether this feature is worth bringing back and how exactly it should behave.

### follow-up tasks

- select a Zig version should suggest to add or modify `.zigversion` or `build.zig.zon`
- make it clear that the currently use Zig version does not match the `.zigversion` or `build.zig.zon`
- make it possible to explicitly uninstall Zig builds (I believe that the quickpick popup can have buttons)
- emit a warning if the installed Zig version does not satisfy the `minimum_zig_version`
- make it clear that the 'Select and Install' popup is in "offline mode"
- bring back checkForUpdate if possible

---

I wanted to keep these changes as small as possible but I couldn't stop myself. :disappointed: 
Any feedback would be greatly appreciated.