### PR TITLE
clear ast-check diagnostics when no errors are reported

### DIFF
--- a/src/zigCompilerProvider.ts
+++ b/src/zigCompilerProvider.ts
@@ -98,7 +98,10 @@ export default class ZigCompilerProvider {
             timeout: 60000, // 60 seconds (this is a very high value because 'zig ast-check' is just in time compiled)
         });
 
-        if (error ?? stderr.length === 0) return;
+        if (error ?? stderr.length === 0) {
+            this.astDiagnostics.delete(textDocument.uri);
+            return;
+        }
 
         const diagnostics: Record<string, vscode.Diagnostic[] | undefined> = {};
         const regex = /(\S.*):(\d*):(\d*): ([^:]*): (.*)/g;


### PR DESCRIPTION
When disabling ZLS so that `zig ast-check` diagnostics are provided by the extension itself, the diagnostics are never removed when the file has not errors. The last errors will also remain.