### PR TITLE
update environment variable collection when the zig.path option is set

### DIFF
--- a/src/zigSetup.ts
+++ b/src/zigSetup.ts
@@ -459,6 +459,7 @@ export async function setupZig(context: vscode.ExtensionContext) {
         } else {
             updateStatusItem(statusItem, zigProvider.getZigVersion());
             updateLanguageStatusItem(languageStatusItem, zigProvider.getZigVersion());
+            updateZigEnvironmentVariableCollection(context, zigProvider.getZigPath());
         }
     };
 


### PR DESCRIPTION
This fixes a bug where zig would not be found in the integrated terminal if the `zig.path` config option has been set. This only happens if the environment variable collection has never been set before in the workspace or if the value is outdated. opening a new workspace is the easiest way to reproduce the issue without modifying the code.