### PR TITLE
don't send empty string configs to ZLS where null would be expected

### DIFF
--- a/src/zls.ts
+++ b/src/zls.ts
@@ -175,6 +175,9 @@ async function configurationMiddleware(
         const configValue = configuration.get(section);
         if (typeof configValue === "string" && configValue) {
             result[index] = handleConfigOption(configValue);
+        } else {
+            // Make sure that `""` gets converted to `null`
+            result[index] = null;
         }
     }
 

--- a/src/zls.ts
+++ b/src/zls.ts
@@ -422,14 +422,14 @@ export async function activate(context: vscode.ExtensionContext) {
         statusItem,
         vscode.commands.registerCommand("zig.zls.enable", async () => {
             const zlsConfig = vscode.workspace.getConfiguration("zig.zls");
-            await zlsConfig.update("enabled", "on");
+            await zlsConfig.update("enabled", "on", true);
         }),
         vscode.commands.registerCommand("zig.zls.stop", async () => {
             await stopClient();
         }),
         vscode.commands.registerCommand("zig.zls.startRestart", async () => {
             const zlsConfig = vscode.workspace.getConfiguration("zig.zls");
-            await zlsConfig.update("enabled", "on");
+            await zlsConfig.update("enabled", "on", true);
             await restartClient(context);
         }),
         vscode.commands.registerCommand("zig.zls.openOutput", () => {


### PR DESCRIPTION
The extension would send config options with the value`""` instead of `null` for options like `zig_exe_path` or `global_cache_path`. I also implemented a fix in [ZLS](https://github.com/zigtools/zls/commit/6c6923d7b1c4984554dade667f664d21f42b2b6c)