### PR TITLE
sync ZLS options

### DIFF
--- a/package.json
+++ b/package.json
@@ -179,20 +179,14 @@
         "zig.zls.enableBuildOnSave": {
           "scope": "resource",
           "type": "boolean",
-          "description": "Whether to enable build-on-save diagnostics",
-          "default": false
+          "description": "Whether to enable build-on-save diagnostics. Will be automatically enabled if the `build.zig` has declared a 'check' step.",
+          "default": null
         },
-        "zig.zls.buildOnSaveStep": {
+        "zig.zls.buildOnSaveArgs": {
           "scope": "resource",
-          "type": "string",
-          "description": "Select which step should be executed on build-on-save",
-          "default": "install"
-        },
-        "zig.zls.enableAutofix": {
-          "scope": "resource",
-          "type": "boolean",
-          "description": "Whether to automatically fix errors on save. Currently supports adding and removing discards.",
-          "default": false
+          "type": "array",
+          "description": "Specify which arguments should be passed to Zig when running build-on-save.\n\nIf the `build.zig` has declared a 'check' step, it will be preferred over the default 'install' step.",
+          "default": []
         },
         "zig.zls.semanticTokens": {
           "scope": "resource",


### PR DESCRIPTION
- added zig.zls.buildOnSaveArgs
- update zig.zls.enableBuildOnSave
- removed zig.zls.buildOnSaveStep
- removed zig.zls.enableAutofix

The default value of zig.zls.enableBuildOnSave has been set to `null` so that it doesn't default to false. This has the slight downside that the autocomplete in `settings.json` will add `"zig.zls.enableBuildOnSave": null,` which will cause a warning because it doesn't comply with the JSON schema. Changing the JSON schema would break the UI configuration view. A possible solution would be to change `enable_build_on_save` to an enum but I would like to avoid a breaking change for such a minor issue.

The `force_autofix` config option is intentionally not added because it is useless in VS Code. Autofix should be enabled with `editor.codeActionsOnSave`.