### PR TITLE
don't open every zig file in the workspace just to look for tests

### DIFF
--- a/src/zigTestRunnerProvider.ts
+++ b/src/zigTestRunnerProvider.ts
@@ -32,7 +32,6 @@ export default class ZigTestRunnerProvider {
             this.debugTests.bind(this),
             false,
         );
-        void this.findAndRegisterTests();
     }
 
     public activate(subscriptions: vscode.Disposable[]) {
@@ -66,16 +65,6 @@ export default class ZigTestRunnerProvider {
                 this.testController.items.delete(item.id);
             }
         });
-    }
-
-    private async findAndRegisterTests() {
-        const files = await vscode.workspace.findFiles("**/*.zig");
-        for (const file of files) {
-            try {
-                const doc = await vscode.workspace.openTextDocument(file);
-                this._updateTestItems(doc);
-            } catch {}
-        }
     }
 
     private _updateTestItems(textDocument: vscode.TextDocument) {


### PR DESCRIPTION
A while ago I noticed that ZLS started to open files even though I didn't open them myself. I didn't think much of it until I checked out the Zig compiler codebase today and saw ZLS endlessly loading files. The project currently contains 2929 .zig files. The cause has been the ZigTestRunnerProvider which is trying to open every zig file to search for tests. 
Identifying the tests of a workspace is not easily done correctly but this is just asking the extension to self destruct.