### PR TITLE
fix configuration middleware for non string config options

### DIFF
--- a/src/zls.ts
+++ b/src/zls.ts
@@ -173,11 +173,9 @@ async function configurationMiddleware(
         const index = optionIndices[name] as unknown as number;
         const section = name.slice("zig.zls.".length);
         const configValue = configuration.get(section);
-        if (typeof configValue === "string" && configValue) {
-            result[index] = handleConfigOption(configValue);
-        } else {
-            // Make sure that `""` gets converted to `null`
-            result[index] = null;
+        if (typeof configValue === "string") {
+            // Make sure that `""` gets converted to `null` and resolve predefined values
+            result[index] = configValue ? handleConfigOption(configValue) : null;
         }
     }
 


### PR DESCRIPTION
What a silly mistake by me
fixes  #256