### PR TITLE
refer to ZLS as "ZLS language server" instead of "Zig Language Server"

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 - automatic formatting
 - Run/Debug zig program
 - Run/Debug tests
-- optional [Zig Language Server](https://github.com/zigtools/zls) features
+- optional [ZLS language server](https://github.com/zigtools/zls) features
   - completions
   - goto definition/declaration
   - document symbols

--- a/package.json
+++ b/package.json
@@ -122,7 +122,7 @@
           "enumItemLabels": [
             "Off",
             "Extension",
-            "Zig Language Server"
+            "ZLS language server"
           ],
           "enumDescriptions": [
             "Disable formatting",
@@ -150,7 +150,7 @@
         "zig.zls.enabled": {
           "scope": "resource",
           "type": "string",
-          "description": "Whether to enable the optional ZLS Language Server",
+          "description": "Whether to enable the optional ZLS language server",
           "enum": [
             "ask",
             "off",
@@ -334,17 +334,17 @@
       {
         "command": "zig.zls.enable",
         "title": "Enable Language Server",
-        "category": "Zig Language Server"
+        "category": "ZLS language server"
       },
       {
         "command": "zig.zls.startRestart",
         "title": "Start / Restart Language Server",
-        "category": "Zig Language Server"
+        "category": "ZLS language server"
       },
       {
         "command": "zig.zls.stop",
         "title": "Stop Language Server",
-        "category": "Zig Language Server"
+        "category": "ZLS language server"
       }
     ],
     "jsonValidation": [

--- a/src/zls.ts
+++ b/src/zls.ts
@@ -46,9 +46,9 @@ export async function restartClient(context: vscode.ExtensionContext): Promise<v
         updateStatusItem(result.version);
     } catch (reason) {
         if (reason instanceof Error) {
-            void vscode.window.showWarningMessage(`Failed to run Zig Language Server (ZLS): ${reason.message}`);
+            void vscode.window.showWarningMessage(`Failed to run ZLS language server: ${reason.message}`);
         } else {
-            void vscode.window.showWarningMessage("Failed to run Zig Language Server (ZLS)");
+            void vscode.window.showWarningMessage("Failed to run ZLS language server");
         }
         updateStatusItem(null);
     }
@@ -85,7 +85,7 @@ async function startClient(zlsPath: string, zlsVersion: semver.SemVer): Promise<
         },
     };
 
-    const languageClient = new LanguageClient("zig.zls", "Zig Language Server", serverOptions, clientOptions);
+    const languageClient = new LanguageClient("zig.zls", "ZLS language server", serverOptions, clientOptions);
     await languageClient.start();
     // Formatting is handled by `zigFormat.ts`
     languageClient.getFeature("textDocument/formatting").dispose();
@@ -329,7 +329,7 @@ async function isEnabled(): Promise<boolean> {
             return false;
         case "ask": {
             const response = await vscode.window.showInformationMessage(
-                "We recommend enabling the ZLS Language Server for a better editing experience. Would you like to install it?",
+                "We recommend enabling the ZLS language server for a better editing experience. Would you like to install it?",
                 { modal: true },
                 "Yes",
                 "No",
@@ -410,7 +410,7 @@ export async function activate(context: vscode.ExtensionContext) {
         },
     };
 
-    outputChannel = vscode.window.createOutputChannel("Zig Language Server");
+    outputChannel = vscode.window.createOutputChannel("ZLS language server");
     statusItem = vscode.languages.createLanguageStatusItem("zig.zls.status", ZIG_MODE);
     statusItem.name = "ZLS";
     updateStatusItem(null);


### PR DESCRIPTION
I have made a similar [change](https://github.com/zigtools/zls/commit/33f5f98c85790a49a49ca1e33170a9642146c31b) to ZLS in the past with the following rationale:
> This is made to avoid ZLS being called "the Zig Language Server" (or "the LSP") which implies ZLS being "official" / developed by the ZSF.
> Obviously, ZLS still remains a acronym for "Zig Language Server".