### PR TITLE
fix zigProvider when modifying zig.path config option

### DIFF
--- a/src/zigProvider.ts
+++ b/src/zigProvider.ts
@@ -21,7 +21,7 @@ export class ZigProvider implements vscode.Disposable {
                 if (change.affectsConfiguration("zig.path")) {
                     const newValue = this.resolveZigPathConfigOption();
                     if (newValue) {
-                        this.set(this.value);
+                        this.set(newValue);
                     }
                 }
             }),


### PR DESCRIPTION
The active Zig executable would previously not be updated when changing the `zig.path` config option.

Regression introduced in adef1d3033644422dfe7059b46c8ab2b9fea2a66.