### PR TITLE
prevent cases where ZLS is started multiple times

### DIFF
--- a/src/zigSetup.ts
+++ b/src/zigSetup.ts
@@ -3,6 +3,7 @@ import vscode from "vscode";
 import path from "path";
 
 import axios from "axios";
+import { debounce } from "lodash-es";
 import semver from "semver";
 
 import * as minisign from "./minisign";
@@ -452,7 +453,7 @@ export async function setupZig(context: vscode.ExtensionContext) {
     const watcher1 = vscode.workspace.createFileSystemWatcher("**/.zigversion");
     const watcher2 = vscode.workspace.createFileSystemWatcher("**/build.zig.zon");
 
-    const refreshZigInstallation = async () => {
+    const refreshZigInstallation = debounce(async () => {
         if (!vscode.workspace.getConfiguration("zig").get<string>("path")) {
             await installZig(context);
         } else {
@@ -460,7 +461,7 @@ export async function setupZig(context: vscode.ExtensionContext) {
             updateLanguageStatusItem(languageStatusItem, zigProvider.getZigVersion());
             updateZigEnvironmentVariableCollection(context, zigProvider.getZigPath());
         }
-    };
+    }, 200);
 
     const onDidChangeActiveTextEditor = (editor: vscode.TextEditor | undefined) => {
         if (editor?.document.languageId === "zig") {

--- a/src/zls.ts
+++ b/src/zls.ts
@@ -41,7 +41,7 @@ export async function restartClient(context: vscode.ExtensionContext): Promise<v
 
     try {
         const newClient = await startClient(result.exe, result.version);
-        await stopClient();
+        void stopClient();
         client = newClient;
         updateStatusItem(result.version);
     } catch (reason) {
@@ -94,11 +94,12 @@ async function startClient(zlsPath: string, zlsVersion: semver.SemVer): Promise<
 
 async function stopClient(): Promise<void> {
     if (!client) return;
-    // The `stop` call will send the "shutdown" notification to the LSP
-    await client.stop();
-    // The `dipose` call will send the "exit" request to the LSP which actually tells the child process to exit
-    await client.dispose();
+    const oldClient = client;
     client = null;
+    // The `stop` call will send the "shutdown" notification to the LSP
+    await oldClient.stop();
+    // The `dipose` call will send the "exit" request to the LSP which actually tells the child process to exit
+    await oldClient.dispose();
 }
 
 /** returns the file system path to the zls executable */


### PR DESCRIPTION
I recently noticed this happening more frequently because of the added file watching on `.zigversion` and `build.zig.zon` files. This is relatively easy to reproduce by using version control to simultaneously change both files. The result is the following:
![Screenshot From 2024-12-30 03-00-03](https://github.com/user-attachments/assets/f343b9ce-4a1d-4caa-849a-271fa0f80836)
