### PR TITLE
fix the remove unused installations cleanup

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,11 +1,11 @@
 import vscode from "vscode";
 
 import { activate as activateZls, deactivate as deactivateZls } from "./zls";
-import { deactivate as deactivateSetupZig, setupZig } from "./zigSetup";
 import ZigDiagnosticsProvider from "./zigDiagnosticsProvider";
 import ZigMainCodeLensProvider from "./zigMainCodeLens";
 import ZigTestRunnerProvider from "./zigTestRunnerProvider";
 import { registerDocumentFormatting } from "./zigFormat";
+import { setupZig } from "./zigSetup";
 
 export async function activate(context: vscode.ExtensionContext) {
     await setupZig(context).finally(() => {
@@ -31,5 +31,4 @@ export async function activate(context: vscode.ExtensionContext) {
 
 export async function deactivate() {
     await deactivateZls();
-    await deactivateSetupZig();
 }

--- a/src/zigSetup.ts
+++ b/src/zigSetup.ts
@@ -584,7 +584,3 @@ export async function setupZig(context: vscode.ExtensionContext) {
 
     await refreshZigInstallation();
 }
-
-export async function deactivate() {
-    await versionManager.removeUnusedInstallations(versionManagerConfig);
-}

--- a/src/zls.ts
+++ b/src/zls.ts
@@ -460,5 +460,4 @@ export async function activate(context: vscode.ExtensionContext) {
 
 export async function deactivate(): Promise<void> {
     await stopClient();
-    await versionManager.removeUnusedInstallations(versionManagerConfig);
 }


### PR DESCRIPTION
The VS Code documentation says that the deactivate function can be async but it doesn't seem to work.

The sorting was also wrong.