### PR TITLE
update descriptions of config options

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
         "zig.buildOnSave": {
           "type": "boolean",
           "default": false,
-          "description": "Compiles code on file save using the settings specified in 'Build Option'."
+          "description": "Compiles code on file save using the settings specified in 'Build Option'. Should not be used with ZLS's build on save feature."
         },
         "zig.buildOption": {
           "type": "string",

--- a/package.json
+++ b/package.json
@@ -181,10 +181,16 @@
           "description": "Whether to enable function argument placeholder completions",
           "default": true
         },
+        "zig.zls.completionLabelDetails": {
+          "scope": "resource",
+          "type": "boolean",
+          "description": "Whether to show the function signature in completion results. May improve readability in some editors when disabled",
+          "default": true
+        },
         "zig.zls.enableBuildOnSave": {
           "scope": "resource",
           "type": "boolean",
-          "description": "Whether to enable build-on-save diagnostics. Will be automatically enabled if the `build.zig` has declared a 'check' step.",
+          "description": "Whether to enable build-on-save diagnostics. Will be automatically enabled if the `build.zig` has declared a 'check' step.\n\nFor more infromation, checkout the [Build-On-Save](https://zigtools.org/zls/guides/build-on-save/) Guide.",
           "default": null
         },
         "zig.zls.buildOnSaveArgs": {
@@ -237,13 +243,13 @@
         "zig.zls.inlayHintsHideRedundantParamNames": {
           "scope": "resource",
           "type": "boolean",
-          "description": "Hides inlay hints when parameter name matches the identifier (e.g. foo: foo)",
+          "description": "Hides inlay hints when parameter name matches the identifier (e.g. `foo: foo`)",
           "default": false
         },
         "zig.zls.inlayHintsHideRedundantParamNamesLastToken": {
           "scope": "resource",
           "type": "boolean",
-          "description": "Hides inlay hints when parameter name matches the last token of a parameter node (e.g. foo: bar.foo, foo: &foo)",
+          "description": "Hides inlay hints when parameter name matches the last token of a parameter node (e.g. `foo: bar.foo`, `foo: &foo`)",
           "default": false
         },
         "zig.zls.warnStyle": {
@@ -261,44 +267,38 @@
         "zig.zls.skipStdReferences": {
           "scope": "resource",
           "type": "boolean",
-          "description": "When true, skips searching for references in std. Improves lookup speed for functions in user's code. Renaming and go-to-definition will continue to work as is",
+          "description": "When true, skips searching for references in the standard library. Improves lookup speed for functions in user's code. Renaming and go-to-definition will continue to work as is",
           "default": false
         },
         "zig.zls.preferAstCheckAsChildProcess": {
           "scope": "resource",
           "type": "boolean",
-          "description": "Favor using `zig ast-check` instead of ZLS's fork",
+          "description": "Favor using `zig ast-check` instead of the builtin one",
           "default": true
         },
         "zig.zls.builtinPath": {
           "scope": "resource",
           "type": "string",
-          "description": "Path to 'builtin;' useful for debugging, automatically set if let null",
+          "description": "Override the path to 'builtin' module. Automatically resolved if unset.",
           "format": "path"
         },
         "zig.zls.zigLibPath": {
           "scope": "resource",
           "type": "string",
-          "description": "Zig library path, e.g. `/path/to/zig/lib/zig`, used to analyze std library imports",
+          "description": "Override the Zig library path. Will be automatically resolved using the 'zig_exe_path'.",
           "format": "path"
         },
         "zig.zls.buildRunnerPath": {
           "scope": "resource",
           "type": "string",
-          "description": "Path to the `build_runner.zig` file provided by ZLS. null is equivalent to `${executable_directory}/build_runner.zig`",
+          "description": "Specify a custom build runner to resolve build system information.",
           "format": "path"
         },
         "zig.zls.globalCachePath": {
           "scope": "resource",
           "type": "string",
-          "description": "Path to a directory that will be used as zig's cache. null is equivalent to `${KnownFolders.Cache}/zls`",
+          "description": "Path to a directory that will be used as zig's cache. Will default to `${KnownFolders.Cache}/zls`.",
           "format": "path"
-        },
-        "zig.zls.completionLabelDetails": {
-          "scope": "resource",
-          "type": "boolean",
-          "description": "When false, the function signature of completion results is hidden. Improves readability in some editors",
-          "default": true
         },
         "zig.zls.additionalOptions": {
           "scope": "resource",


### PR DESCRIPTION
See https://github.com/zigtools/zls/commit/c0e69f7633281126c80bc158c0393c901bb6efce

I also updated the description of `zig.buildOnSave` to warn against usage with `zig.zls.enable_build_on_save`. Related discussion in https://github.com/ziglang/vscode-zig/issues/261.