### PR TITLE
various version manager improvements

### DIFF
--- a/src/zigSetup.ts
+++ b/src/zigSetup.ts
@@ -495,11 +495,9 @@ function updateLanguageStatusItem(item: vscode.LanguageStatusItem, version: semv
 
 function updateZigEnvironmentVariableCollection(context: vscode.ExtensionContext, zigExePath: string | null) {
     if (zigExePath) {
-        const envValue = path.delimiter + path.dirname(zigExePath);
-        // Calling `append` means that zig from a user-defined PATH value will take precedence.
-        // The added value may have already been added by the user but since we
-        // append, it doesn't have any observable.
-        context.environmentVariableCollection.append("PATH", envValue);
+        const envValue = path.dirname(zigExePath) + path.delimiter;
+        // This will take priority over a user-defined PATH values.
+        context.environmentVariableCollection.prepend("PATH", envValue);
     } else {
         context.environmentVariableCollection.delete("PATH");
     }

--- a/src/zigSetup.ts
+++ b/src/zigSetup.ts
@@ -532,7 +532,7 @@ async function updateStatus(context: vscode.ExtensionContext): Promise<void> {
 
     void vscode.window
         .showWarningMessage(
-            `Your Zig version '${zigVersion.toString()}' does not satify the minimum Zig version '${buildZigZonMetadata.minimumZigVersion.toString()}' of your project.`,
+            `Your Zig version '${zigVersion.toString()}' does not satisfy the minimum Zig version '${buildZigZonMetadata.minimumZigVersion.toString()}' of your project.`,
             "update Zig",
             "open build.zig.zon",
         )

--- a/src/zigSetup.ts
+++ b/src/zigSetup.ts
@@ -298,26 +298,28 @@ async function showUpdateWorkspaceVersionDialog(
 ): Promise<void> {
     const workspace = getWorkspaceFolder();
 
-    source ??= workspace
-        ? WantedZigVersionSource.workspaceZigVersionFile
-        : WantedZigVersionSource.zigVersionConfigOption;
-
-    let sourceName;
+    let buttonName;
     switch (source) {
         case WantedZigVersionSource.workspaceZigVersionFile:
-            sourceName = ".ziversion";
+            buttonName = "update .zigversion";
             break;
         case WantedZigVersionSource.workspaceBuildZigZon:
-            sourceName = "build.zig.zon";
+            buttonName = "update build.zig.zon";
             break;
         case WantedZigVersionSource.zigVersionConfigOption:
-            sourceName = "workspace settings";
+            buttonName = "update workspace settings";
+            break;
+        default:
+            source = workspace
+                ? WantedZigVersionSource.workspaceZigVersionFile
+                : WantedZigVersionSource.zigVersionConfigOption;
+            buttonName = workspace ? "create .zigversion" : "update settings";
             break;
     }
 
     const response = await vscode.window.showInformationMessage(
-        "Would you like to save this version for this workspace?",
-        `update ${sourceName}`,
+        `Would you like to save Zig ${version.toString()} in this workspace?`,
+        buttonName,
     );
     if (!response) return;
 

--- a/src/zigSetup.ts
+++ b/src/zigSetup.ts
@@ -298,30 +298,33 @@ async function showUpdateWorkspaceVersionDialog(
 ): Promise<void> {
     const workspace = getWorkspaceFolder();
 
-    let buttonName;
-    switch (source) {
-        case WantedZigVersionSource.workspaceZigVersionFile:
-            buttonName = "update .zigversion";
-            break;
-        case WantedZigVersionSource.workspaceBuildZigZon:
-            buttonName = "update build.zig.zon";
-            break;
-        case WantedZigVersionSource.zigVersionConfigOption:
-            buttonName = "update workspace settings";
-            break;
-        default:
-            source = workspace
-                ? WantedZigVersionSource.workspaceZigVersionFile
-                : WantedZigVersionSource.zigVersionConfigOption;
-            buttonName = workspace ? "create .zigversion" : "update settings";
-            break;
+    if (workspace !== null) {
+        let buttonName;
+        switch (source) {
+            case WantedZigVersionSource.workspaceZigVersionFile:
+                buttonName = "update .zigversion";
+                break;
+            case WantedZigVersionSource.workspaceBuildZigZon:
+                buttonName = "update build.zig.zon";
+                break;
+            case WantedZigVersionSource.zigVersionConfigOption:
+                buttonName = "update workspace settings";
+                break;
+            case undefined:
+                buttonName = "create .zigversion";
+                break;
+        }
+
+        const response = await vscode.window.showInformationMessage(
+            `Would you like to save Zig ${version.toString()} in this workspace?`,
+            buttonName,
+        );
+        if (!response) return;
     }
 
-    const response = await vscode.window.showInformationMessage(
-        `Would you like to save Zig ${version.toString()} in this workspace?`,
-        buttonName,
-    );
-    if (!response) return;
+    source ??= workspace
+        ? WantedZigVersionSource.workspaceZigVersionFile
+        : WantedZigVersionSource.zigVersionConfigOption;
 
     switch (source) {
         case WantedZigVersionSource.workspaceZigVersionFile: {

--- a/src/zigSetup.ts
+++ b/src/zigSetup.ts
@@ -286,8 +286,8 @@ async function selectVersionAndInstall(context: vscode.ExtensionContext) {
             break;
         default:
             const version = new semver.SemVer(selection.detail ?? selection.label);
+            await showUpdateWorkspaceVersionDialog(version, workspaceZig?.source);
             await installZig(context, version);
-            void showUpdateWorkspaceVersionDialog(version, workspaceZig?.source);
             break;
     }
 }


### PR DESCRIPTION
This PR applies three changes to the version manager. The changes correspond the first three commits.

### offer to update workspace config files when selecting Zig version

fixes #247

Using the "Select and Install" popup to switch to a different Zig version will no longer be saved permanently. It will revert to the previous version after restarting VS Code. To make the change permanent, the version should be saved in a `.zigversion`, `build.zig.zon` or `settings.json` file. The extension will automatically suggest this change with a message. If not workspace config has been found, a `.zigversion` file will be created.

I am open to any better wording suggestions for the message. This is what I went for:

![Screenshot From 2025-01-23 18-30-30](https://github.com/user-attachments/assets/d4a3b235-c31b-4026-b371-3d57fa33c957)

### lookup Zig in the $PATH if no workspace version has been specified.

If the workspace specified no Zig version, the extension would automatically install the latest tagged release. This commit will try to lookup Zig in the $PATH before falling back to the latest tagged release. This is meant to avoid confusing users why their already installed Zig version is not being used.

### override the $PATH in the integrated terminal

Previously, if the $PATH has a zig version, the integrated terminal would prefer it over the version that is used by the version manager. Thanks to the previous commit, it now makes more sense to override the $PATH. This means that the integrated terminal will use the Zig version requested by the workspace even if the user added Zig to the $PATH.