### PR TITLE
don't send default config values to ZLS

### DIFF
--- a/src/zls.ts
+++ b/src/zls.ts
@@ -178,6 +178,16 @@ async function configurationMiddleware(
             // Make sure that `""` gets converted to `null` and resolve predefined values
             result[index] = configValue ? handleConfigOption(configValue) : null;
         }
+
+        const inspect = configuration.inspect(section);
+        const isDefaultValue =
+            configValue === inspect?.defaultValue &&
+            inspect?.globalValue === undefined &&
+            inspect?.workspaceValue === undefined &&
+            inspect?.workspaceFolderValue === undefined;
+        if(isDefaultValue) {
+            result[index] = null;
+        }
     }
 
     const indexOfZigPath = optionIndices["zig.path"];


### PR DESCRIPTION
This will prevent config options set in the zls.json from being overridden with default values by the extension.

VS Code, in their infinite wisdom, has chosen to default boolean config options to false and string options to an empty string (""), ensuring that null or undefined are never returned.

See zigtools/zls#2135