### PR TITLE
guard against exceptions when updating configuration

### DIFF
--- a/src/zigProvider.ts
+++ b/src/zigProvider.ts
@@ -2,7 +2,7 @@ import vscode from "vscode";
 
 import semver from "semver";
 
-import { resolveExePathAndVersion } from "./zigUtil";
+import { resolveExePathAndVersion, workspaceConfigUpdateNoThrow } from "./zigUtil";
 
 interface ExeWithVersion {
     exe: string;
@@ -50,13 +50,14 @@ export class ZigProvider implements vscode.Disposable {
      * @param zigPath The path to the zig executable. If `null`, the `zig.path` config option will be removed.
      */
     public async setAndSave(zigPath: string | null) {
+        const zigConfig = vscode.workspace.getConfiguration("zig");
         if (!zigPath) {
-            await vscode.workspace.getConfiguration("zig").update("path", undefined, true);
+            await workspaceConfigUpdateNoThrow(zigConfig, "path", undefined, true);
             return;
         }
         const newValue = this.resolveZigPathConfigOption(zigPath);
         if (!newValue) return;
-        await vscode.workspace.getConfiguration("zig").update("path", newValue.exe, true);
+        await workspaceConfigUpdateNoThrow(zigConfig, "path", newValue.exe, true);
         this.set(newValue);
     }
 

--- a/src/zigUtil.ts
+++ b/src/zigUtil.ts
@@ -121,6 +121,28 @@ export function asyncDebounce<T extends (...args: unknown[]) => Promise<Awaited<
         });
 }
 
+/**
+ * Wrapper around `vscode.WorkspaceConfiguration.update` that doesn't throw an exception.
+ * A common cause of an exception is when the `settings.json` file is read-only.
+ */
+export async function workspaceConfigUpdateNoThrow(
+    config: vscode.WorkspaceConfiguration,
+    section: string,
+    value: unknown,
+    configurationTarget?: vscode.ConfigurationTarget | boolean | null,
+    overrideInLanguage?: boolean,
+): Promise<void> {
+    try {
+        await config.update(section, value, configurationTarget, overrideInLanguage);
+    } catch (err) {
+        if (err instanceof Error) {
+            void vscode.window.showErrorMessage(err.message);
+        } else {
+            void vscode.window.showErrorMessage("failed to update settings.json");
+        }
+    }
+}
+
 // Check timestamp `key` to avoid automatically checking for updates
 // more than once in an hour.
 export async function shouldCheckUpdate(context: vscode.ExtensionContext, key: string): Promise<boolean> {


### PR DESCRIPTION
When an exception occurs because it is updating a read-only settings.json to remove the outdated `initialSetupDone` config option, the extensions fails to initialize properly.

See #392