### PR TITLE
feat: run test through filtered 'zig build test' instead of 'zig test' if build.zig is present.

### DIFF
--- a/package.json
+++ b/package.json
@@ -141,8 +141,8 @@
           "items": {
             "type": "string"
           },
-          "default": [],
-          "description": "Extra arguments to passed to 'zig build' when running tests."
+          "default": ["test", "--test-filter", "${filter}", "${path}"],
+          "description": "Arguments to pass to 'zig' for running tests. Supported variables: ${filter}, ${path}."
         },
         "zig.zls.debugLog": {
           "scope": "resource",

--- a/package.json
+++ b/package.json
@@ -141,7 +141,12 @@
           "items": {
             "type": "string"
           },
-          "default": ["test", "--test-filter", "${filter}", "${path}"],
+          "default": [
+            "test",
+            "--test-filter",
+            "${filter}",
+            "${path}"
+          ],
           "description": "Arguments to pass to 'zig' for running tests. Supported variables: ${filter}, ${path}."
         },
         "zig.zls.debugLog": {

--- a/package.json
+++ b/package.json
@@ -136,6 +136,14 @@
           ],
           "default": "zls"
         },
+        "zig.testArgs": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": [],
+          "description": "Extra arguments to passed to 'zig build' when running tests."
+        },
         "zig.zls.debugLog": {
           "scope": "resource",
           "type": "boolean",

--- a/src/zigTestRunnerProvider.ts
+++ b/src/zigTestRunnerProvider.ts
@@ -70,7 +70,7 @@ export default class ZigTestRunnerProvider {
     private _updateTestItems(textDocument: vscode.TextDocument) {
         if (textDocument.languageId !== "zig") return;
 
-const regex = /\btest\s(?:"([^"])"|([a-zA-Z0-9_][\w]*)|@"([^"])")\s*\{/g;
+        const regex = /\btest\s(?:"([^"])"|([a-zA-Z0-9_][\w]*)|@"([^"])")\s*\{/g;
         const matches = Array.from(textDocument.getText().matchAll(regex));
         this.deleteTestForAFile(textDocument.uri);
 
@@ -144,28 +144,6 @@ const regex = /\btest\s(?:"([^"])"|([a-zA-Z0-9_][\w]*)|@"([^"])")\s*\{/g;
             return { output: output.replaceAll("\n", "\r\n"), success: true };
         } catch (e) {
             if (e instanceof Error) {
-                if (
-                    config.get<string[]>("testArgs")?.toString() === config.inspect<string[]>("testArgs")?.defaultValue?.toString() &&
-                    (e.message.includes("error: no module named") ||
-                        e.message.includes("error: import of file outside module path"))
-                ) {
-                    void vscode.window
-                        .showInformationMessage("Use build script to run tests?", "Yes", "No")
-                        .then(async (response) => {
-                            if (response === "Yes") {
-                                await workspaceConfigUpdateNoThrow(
-                                    config,
-                                    "testArgs",
-                                    ["build", "test-unit", "-Dtest-filter=${filter}"],
-                                    false,
-                                );
-                                void vscode.commands.executeCommand(
-                                    "workbench.action.openSettings",
-                                    "@id:zig.testArgs",
-                                );
-                            }
-                        });
-                }
                 return { output: e.message.replaceAll("\n", "\r\n"), success: false };
             } else {
                 return { output: "Failed to run test\r\n", success: false };

--- a/src/zigTestRunnerProvider.ts
+++ b/src/zigTestRunnerProvider.ts
@@ -70,7 +70,7 @@ export default class ZigTestRunnerProvider {
     private _updateTestItems(textDocument: vscode.TextDocument) {
         if (textDocument.languageId !== "zig") return;
 
-        const regex = /\btest\s(?:"([^"])"|([a-zA-Z0-9_][\w]*)|@"([^"])")\s*\{/g;
+        const regex = /\btest\s+(?:"([^"]+)"|([a-zA-Z0-9_][\w]*)|@"([^"]+)")\s*\{/g;
         const matches = Array.from(textDocument.getText().matchAll(regex));
         this.deleteTestForAFile(textDocument.uri);
 

--- a/src/zigTestRunnerProvider.ts
+++ b/src/zigTestRunnerProvider.ts
@@ -133,10 +133,11 @@ export default class ZigTestRunnerProvider {
         const parts = test.id.split(".");
         const lastPart = parts[parts.length - 1];
 
-        const testArgsConf = config.get<string[]>('testArgs') || [];
-        const args: string[] = (testArgsConf.length > 0)
-            ? testArgsConf.map((v) => v.replace("${filter}", lastPart).replace("${path}", testUri.fsPath))
-            : [];
+        const testArgsConf = config.get<string[]>("testArgs") || [];
+        const args: string[] =
+            testArgsConf.length > 0
+                ? testArgsConf.map((v) => v.replace("${filter}", lastPart).replace("${path}", testUri.fsPath))
+                : [];
 
         try {
             const { stderr: output } = await execFile(zigPath, args, { cwd: wsFolder });
@@ -145,9 +146,9 @@ export default class ZigTestRunnerProvider {
         } catch (e) {
             if (e instanceof Error) {
                 if (
-                    config.get<string[]>("testArgs")?.toString() === config.inspect<string[]>("testArgs")?.defaultValue?.toString() &&
-                    (e.message.includes("no module named") ||
-                        e.message.includes("import of file outside module path"))
+                    config.get<string[]>("testArgs")?.toString() ===
+                        config.inspect<string[]>("testArgs")?.defaultValue?.toString() &&
+                    (e.message.includes("no module named") || e.message.includes("import of file outside module path"))
                 ) {
                     void vscode.window
                         .showInformationMessage("Use build script to run tests?", "Yes", "No")

--- a/src/zigTestRunnerProvider.ts
+++ b/src/zigTestRunnerProvider.ts
@@ -128,14 +128,16 @@ export default class ZigTestRunnerProvider {
             return { output: "Unable to determine file location", success: false };
         }
 
-        const wsFolder = getWorkspaceFolder(test.uri.fsPath)?.uri.fsPath ?? path.dirname(test.uri.fsPath);
+        const testUri = test.uri;
+        const wsFolder = getWorkspaceFolder(testUri.fsPath)?.uri.fsPath ?? path.dirname(testUri.fsPath);
 
         const parts = test.id.split(".");
         const lastPart = parts[parts.length - 1];
 
-        const defaultArgs = ["test", "--test-filter", lastPart, test.uri.fsPath];
-        const testArgs = config.get<Array<string>>('testArgs') || [];
-        const args = testArgs.length > 0 ? ["build"].concat(testArgs).concat([lastPart]) : defaultArgs;
+        const testArgsConf = config.get<Array<string>>('testArgs') || [];
+        const args: Array<string> = (testArgsConf.length > 0)
+            ? testArgsConf.map((v) => v.replace("${filter}", lastPart).replace("${path}", testUri.fsPath))
+            : [];
 
         try {
             const { stderr: output } = await execFile(zigPath, args, { cwd: wsFolder });

--- a/src/zigTestRunnerProvider.ts
+++ b/src/zigTestRunnerProvider.ts
@@ -141,7 +141,7 @@ const regex = /\btest\s(?:"([^"])"|([a-zA-Z0-9_][\w]*)|@"([^"])")\s*\{/g;
         try {
             const { stderr: output } = await execFile(zigPath, args, { cwd: wsFolder });
 
-            return { output: output, success: true };
+            return { output: output.replaceAll("\n", "\r\n"), success: true };
         } catch (e) {
             if (e instanceof Error) {
                 if (
@@ -166,9 +166,9 @@ const regex = /\btest\s(?:"([^"])"|([a-zA-Z0-9_][\w]*)|@"([^"])")\s*\{/g;
                             }
                         });
                 }
-                return { output: e.message, success: false };
+                return { output: e.message.replaceAll("\n", "\r\n"), success: false };
             } else {
-                return { output: "Failed to run test", success: false };
+                return { output: "Failed to run test\r\n", success: false };
             }
         }
     }

--- a/src/zigTestRunnerProvider.ts
+++ b/src/zigTestRunnerProvider.ts
@@ -1,7 +1,6 @@
 import vscode from "vscode";
 
 import childProcess from "child_process";
-import fs from "fs";
 import path from "path";
 import util from "util";
 
@@ -134,8 +133,8 @@ export default class ZigTestRunnerProvider {
         const parts = test.id.split(".");
         const lastPart = parts[parts.length - 1];
 
-        const testArgsConf = config.get<Array<string>>('testArgs') || [];
-        const args: Array<string> = (testArgsConf.length > 0)
+        const testArgsConf = config.get<string[]>('testArgs') || [];
+        const args: string[] = (testArgsConf.length > 0)
             ? testArgsConf.map((v) => v.replace("${filter}", lastPart).replace("${path}", testUri.fsPath))
             : [];
 

--- a/src/zigTestRunnerProvider.ts
+++ b/src/zigTestRunnerProvider.ts
@@ -133,7 +133,7 @@ export default class ZigTestRunnerProvider {
         const parts = test.id.split(".");
         const lastPart = parts[parts.length - 1];
 
-        const testArgsConf = config.get<string[]>("testArgs") || [];
+        const testArgsConf = config.get<string[]>("testArgs") ?? [];
         const args: string[] =
             testArgsConf.length > 0
                 ? testArgsConf.map((v) => v.replace("${filter}", lastPart).replace("${path}", testUri.fsPath))


### PR DESCRIPTION
[![Open Source Saturday](https://img.shields.io/badge/%E2%9D%A4%EF%B8%8F-open%20source%20saturday-F64060.svg)](https://lu.ma/open-source-saturday-torino)

Hi! This PR introduces the ability to run a single test through the Code Lens button leveraging the build.zig file, if present. If not, it will fallback to the previous mechanism.

The reason for this is leveraging the full configuration encoded in the build script, as opposed run on a specific file, which could not work under certain conditions such as importing a file from outside the current module (eg: https://github.com/omissis/zig-langchain/blob/main/src/openai/OpenAI.zig#L2).

By running through `zig build test --summary all -- TESTNAME`, such test can be run in isolation during development, allowing for a tight feedback loop.

This is probably tackling what asked for in https://github.com/ziglang/vscode-zig/issues/390