### PR TITLE
ensure that CI will fail if the code is not properly formatted

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ jobs:
       - run: npm run build
       - run: npm run typecheck
       - run: npm run lint
-      - run: npm run format -- --check
+      - run: npm run format:check
 
       - name: package extension
         run: |

--- a/package.json
+++ b/package.json
@@ -367,6 +367,7 @@
     "test": "npm run compile && node ./node_modules/vscode/bin/test",
     "typecheck": "tsc --noEmit",
     "format": "prettier --write .",
+    "format:check": "prettier --check .",
     "lint": "eslint ."
   },
   "devDependencies": {

--- a/src/zigMainCodeLens.ts
+++ b/src/zigMainCodeLens.ts
@@ -56,7 +56,7 @@ function zigRun() {
 
 function escapePath(rawPath: string): string {
     if (/[ !"#$&'()*,;:<>?\[\\\]^`{|}]/.test(rawPath)) {
-        return `"${rawPath.replaceAll("\"", "\"\\\"\"")}"`;
+        return `"${rawPath.replaceAll('"', '"\\""')}"`;
     }
     return rawPath;
 }

--- a/src/zls.ts
+++ b/src/zls.ts
@@ -185,7 +185,7 @@ async function configurationMiddleware(
             inspect?.globalValue === undefined &&
             inspect?.workspaceValue === undefined &&
             inspect?.workspaceFolderValue === undefined;
-        if(isDefaultValue) {
+        if (isDefaultValue) {
             result[index] = null;
         }
     }


### PR DESCRIPTION
The CI would previously run `prettier --write . --check` but it should be doing `prettier --check .`