### PR TITLE
add buttons to the error message when ZLS could not be found

### DIFF
--- a/src/zls.ts
+++ b/src/zls.ts
@@ -113,7 +113,20 @@ async function getZLSPath(context: vscode.ExtensionContext): Promise<{ exe: stri
         // It should be more likely that the given executable is invalid than someone using ZLS 0.9.0 or older.
         const result = resolveExePathAndVersion(zlsExePath, "zls", "zig.zls.path", "--version");
         if ("message" in result) {
-            void vscode.window.showErrorMessage(result.message);
+            vscode.window.showErrorMessage(result.message, "install ZLS", "open settings").then(async (response) => {
+                switch (response) {
+                    case "install ZLS":
+                        const zlsConfig = vscode.workspace.getConfiguration("zig.zls");
+                        await workspaceConfigUpdateNoThrow(zlsConfig, "enabled", "on", true);
+                        await workspaceConfigUpdateNoThrow(zlsConfig, "path", undefined);
+                        break;
+                    case "open settings":
+                        await vscode.commands.executeCommand("workbench.action.openSettings", "zig.zls.path");
+                        break;
+                    case undefined:
+                        break;
+                }
+            });
             return null;
         }
         return result;


### PR DESCRIPTION
![Screenshot_20250326_193121](https://github.com/user-attachments/assets/162f785e-e279-417c-9171-586ebe447c29)

This should make it easier to resolve the problem that has been encountered in #409.
