### PR TITLE
Testrunner: set cwd to project folder of test + no-llvm run option for run test.

### DIFF
--- a/package.json
+++ b/package.json
@@ -136,6 +136,12 @@
           ],
           "default": "zls"
         },
+        "zig.testrunner.no-llvm": {
+         "scope": "resource",
+         "type": "boolean",
+         "description": "Use the non-LLVM experimental x86 backend when running tests. Tests will run significantly faster.",
+         "default": false
+       },
         "zig.zls.debugLog": {
           "scope": "resource",
           "type": "boolean",


### PR DESCRIPTION
Modified the test runner to set the process cwd to the project folder. This is consistent with running tests from the command line in the project folder or running `zig build test` and allows tests to open files relative to the project. For example: 
```zig
test "mytest" {
  var test_file = try std.fs.cwd().openFile("./tests/input", .{});
  ...
}
```
Added a "no-llvm" configuration option that adds -fno-llvm to the Zig command line when using `Run Test`. This enabled the x86 backend and results in significantly faster test execution. 
Unfortunately the x86 backend does not appear to emit all debug symbols. Local variables are not available when debugging with lldb. Therefore no-llvm is disabled for `Debug Test`. When the x86 backend stabilizes, we can enable this feature for `Debug Test`.