### PR TITLE
add toggleMultilineStringLiteral command

### DIFF
--- a/package.json
+++ b/package.json
@@ -337,6 +337,11 @@
         "category": "Zig Setup"
       },
       {
+        "command": "zig.toggleMultilineStringLiteral",
+        "title": "Toggle Multiline String Literal",
+        "category": "Zig"
+      },
+      {
         "command": "zig.zls.enable",
         "title": "Enable Language Server",
         "category": "ZLS language server"
@@ -350,6 +355,14 @@
         "command": "zig.zls.stop",
         "title": "Stop Language Server",
         "category": "ZLS language server"
+      }
+    ],
+    "keybindings": [
+      {
+        "command": "zig.toggleMultilineStringLiteral",
+        "key": "ctrl+m ctrl+s",
+        "mac": "cmd+m cmd+s",
+        "when": "editorTextFocus && editorLangId == 'zig'"
       }
     ],
     "jsonValidation": [

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -23,12 +23,44 @@ export async function activate(context: vscode.ExtensionContext) {
                 { language: "zig", scheme: "file" },
                 new ZigMainCodeLensProvider(),
             ),
+            vscode.commands.registerCommand(
+                'zig.toggleMultilineStringLiteral', 
+                toggleMultilineStringLiteral
+            ),
         );
-
         void activateZls(context);
     });
 }
 
 export async function deactivate() {
     await deactivateZls();
+}
+
+async function toggleMultilineStringLiteral() {
+	const editor = vscode.window.activeTextEditor;
+	if (!editor) { return; }
+	const { document, selection } = editor;
+	if (document.languageId !== 'zig') { return; }
+
+	let newText = '';
+	let range = new vscode.Range(selection.start, selection.end);
+
+	const firstLine = document.lineAt(selection.start.line);
+	const nonWhitespaceIndex = firstLine.firstNonWhitespaceCharacterIndex;
+
+	for (var lineNum = selection.start.line; lineNum <= selection.end.line; lineNum++) {
+		const line = document.lineAt(lineNum);
+
+		const isMLSL = line.text.slice(line.firstNonWhitespaceCharacterIndex).startsWith('\\\\');
+		const breakpoint = Math.min(nonWhitespaceIndex, line.firstNonWhitespaceCharacterIndex);
+
+		const newLine = isMLSL
+			? line.text.slice(0, line.firstNonWhitespaceCharacterIndex) + line.text.slice(line.firstNonWhitespaceCharacterIndex).slice(2)
+			: line.text.slice(0, breakpoint) + '\\\\' + line.text.slice(breakpoint);
+		newText += newLine;
+		if (lineNum < selection.end.line) { newText += '\n'; }
+		range = range.union(line.range);
+	}
+
+	await editor.edit((builder) => builder.replace(range, newText));
 }


### PR DESCRIPTION
This PR creates a command to toggle the lines in the current selection - adding or removing the token from each line as appropriate.

I do a lot of SQL work and tend to copy/paste multiline string literals into my zig source code from other sources.
But I got tired of manually adding the multiline string token `\\` to each line. 

Since there aren't any other stand-alone commands in the project, I added the command function to the extension file. 
I'm guessing that's not the best location, but I figured better to put it there and move it to elsewhere based on feedback.

I mapped this command by default to Ctrl-M Ctrl-S (for Multiline String). 
I think of this command similar to the add/remove line comment commands that are mapped to Ctrl-K Ctrl-C / Ctrl-K Ctrl-U. 
However, I didn't think that removing multiline string literal tokens would be that common scenario, so I created a single toggle command instead of separate add/remove commands.
Happy to change this to separate add/remove commands based on feedback.

