### PR TITLE
improve the Zig and ZLS executable lookup

### DIFF
--- a/src/zigProvider.ts
+++ b/src/zigProvider.ts
@@ -56,8 +56,7 @@ export class ZigProvider {
     public resolveZigPathConfigOption(zigPath?: string): ExeWithVersion | null | undefined {
         zigPath ??= vscode.workspace.getConfiguration("zig").get<string>("path", "");
         if (!zigPath) return null;
-        const exePath = zigPath !== "zig" ? zigPath : null; // the string "zig" means lookup in PATH
-        const result = resolveExePathAndVersion(exePath, "zig", "zig.path", "version");
+        const result = resolveExePathAndVersion(zigPath, "zig.path", "version");
         if ("message" in result) {
             void vscode.window.showErrorMessage(result.message);
             return undefined;

--- a/src/zigProvider.ts
+++ b/src/zigProvider.ts
@@ -56,9 +56,9 @@ export class ZigProvider {
     public resolveZigPathConfigOption(zigPath?: string): ExeWithVersion | null | undefined {
         zigPath ??= vscode.workspace.getConfiguration("zig").get<string>("path", "");
         if (!zigPath) return null;
-        const result = resolveExePathAndVersion(zigPath, "zig.path", "version");
+        const result = resolveExePathAndVersion(zigPath, "version");
         if ("message" in result) {
-            void vscode.window.showErrorMessage(result.message);
+            void vscode.window.showErrorMessage(`Unexpected 'zig.path': ${result.message}`);
             return undefined;
         }
         return result;

--- a/src/zigProvider.ts
+++ b/src/zigProvider.ts
@@ -58,7 +58,24 @@ export class ZigProvider {
         if (!zigPath) return null;
         const result = resolveExePathAndVersion(zigPath, "version");
         if ("message" in result) {
-            void vscode.window.showErrorMessage(`Unexpected 'zig.path': ${result.message}`);
+            vscode.window
+                .showErrorMessage(`Unexpected 'zig.path': ${result.message}`, "install Zig", "open settings")
+                .then(async (response) => {
+                    switch (response) {
+                        case "install Zig":
+                            await workspaceConfigUpdateNoThrow(
+                                vscode.workspace.getConfiguration("zig"),
+                                "path",
+                                undefined,
+                            );
+                            break;
+                        case "open settings":
+                            await vscode.commands.executeCommand("workbench.action.openSettings", "zig.path");
+                            break;
+                        case undefined:
+                            break;
+                    }
+                });
             return undefined;
         }
         return result;

--- a/src/zigSetup.ts
+++ b/src/zigSetup.ts
@@ -39,7 +39,7 @@ async function installZig(context: vscode.ExtensionContext, temporaryVersion?: s
 
     if (!version) {
         // Lookup zig in $PATH
-        const result = resolveExePathAndVersion(null, "zig", null, "version");
+        const result = resolveExePathAndVersion("zig", null, "version");
         if ("exe" in result) {
             await vscode.workspace.getConfiguration("zig").update("path", undefined, true);
             zigProvider.set(result);
@@ -234,7 +234,7 @@ async function selectVersionAndInstall(context: vscode.ExtensionContext) {
         });
     }
 
-    const zigInPath = resolveExePathAndVersion(null, "zig", null, "version");
+    const zigInPath = resolveExePathAndVersion("zig", null, "version");
     if (!("message" in zigInPath)) {
         items.push({
             label: "Use Zig in PATH",

--- a/src/zigSetup.ts
+++ b/src/zigSetup.ts
@@ -39,7 +39,7 @@ async function installZig(context: vscode.ExtensionContext, temporaryVersion?: s
 
     if (!version) {
         // Lookup zig in $PATH
-        const result = resolveExePathAndVersion("zig", null, "version");
+        const result = resolveExePathAndVersion("zig", "version");
         if ("exe" in result) {
             await vscode.workspace.getConfiguration("zig").update("path", undefined, true);
             zigProvider.set(result);
@@ -234,7 +234,7 @@ async function selectVersionAndInstall(context: vscode.ExtensionContext) {
         });
     }
 
-    const zigInPath = resolveExePathAndVersion("zig", null, "version");
+    const zigInPath = resolveExePathAndVersion("zig", "version");
     if (!("message" in zigInPath)) {
         items.push({
             label: "Use Zig in PATH",

--- a/src/zls.ts
+++ b/src/zls.ts
@@ -110,7 +110,7 @@ async function getZLSPath(context: vscode.ExtensionContext): Promise<{ exe: stri
     if (!!zlsExePath) {
         // This will fail on older ZLS version that do not support `zls --version`.
         // It should be more likely that the given executable is invalid than someone using ZLS 0.9.0 or older.
-        const result = resolveExePathAndVersion(zlsExePath, "zls", "zig.zls.path", "--version");
+        const result = resolveExePathAndVersion(zlsExePath, "zig.zls.path", "--version");
         if ("message" in result) {
             vscode.window.showErrorMessage(result.message, "install ZLS", "open settings").then(async (response) => {
                 switch (response) {

--- a/src/zls.ts
+++ b/src/zls.ts
@@ -110,22 +110,24 @@ async function getZLSPath(context: vscode.ExtensionContext): Promise<{ exe: stri
     if (!!zlsExePath) {
         // This will fail on older ZLS version that do not support `zls --version`.
         // It should be more likely that the given executable is invalid than someone using ZLS 0.9.0 or older.
-        const result = resolveExePathAndVersion(zlsExePath, "zig.zls.path", "--version");
+        const result = resolveExePathAndVersion(zlsExePath, "--version");
         if ("message" in result) {
-            vscode.window.showErrorMessage(result.message, "install ZLS", "open settings").then(async (response) => {
-                switch (response) {
-                    case "install ZLS":
-                        const zlsConfig = vscode.workspace.getConfiguration("zig.zls");
-                        await workspaceConfigUpdateNoThrow(zlsConfig, "enabled", "on", true);
-                        await workspaceConfigUpdateNoThrow(zlsConfig, "path", undefined);
-                        break;
-                    case "open settings":
-                        await vscode.commands.executeCommand("workbench.action.openSettings", "zig.zls.path");
-                        break;
-                    case undefined:
-                        break;
-                }
-            });
+            vscode.window
+                .showErrorMessage(`Unexpected 'zig.zls.path': ${result.message}`, "install ZLS", "open settings")
+                .then(async (response) => {
+                    switch (response) {
+                        case "install ZLS":
+                            const zlsConfig = vscode.workspace.getConfiguration("zig.zls");
+                            await workspaceConfigUpdateNoThrow(zlsConfig, "enabled", "on", true);
+                            await workspaceConfigUpdateNoThrow(zlsConfig, "path", undefined);
+                            break;
+                        case "open settings":
+                            await vscode.commands.executeCommand("workbench.action.openSettings", "zig.zls.path");
+                            break;
+                        case undefined:
+                            break;
+                    }
+                });
             return null;
         }
         return result;


### PR DESCRIPTION
It turns out that the 'which' package has the exact logic that is needed to fix #164. A value that has path separators will not be looked up in the $PATH but will try to resolve file extensions on windows.

I've also noticed that it is possible to input relative paths like `./zig` that would be looked up relative to the cwd of the vs code extension host process. Such values will now be rejected with an error message that suggests `${workspaceFolder}` and `~` as an alternative.

The rest of the changes affect error messages which are further explained in the commit messages.