### PR TITLE
Prevent versionManager from installing same version of exe concurrently

### DIFF
--- a/src/versionManager.ts
+++ b/src/versionManager.ts
@@ -58,10 +58,10 @@ export async function install(config: Config, version: semver.SemVer): Promise<s
         return await entry;
     }
 
-    const fn = installGuarded.apply(null, [config, version]);
-    inProgressInstalls.set(key, fn);
+    const promise = installGuarded(config, version);
+    inProgressInstalls.set(key, promise);
 
-    return await fn.finally(() => {
+    return await promise.finally(() => {
         inProgressInstalls.delete(key);
     });
 }


### PR DESCRIPTION
The concurrent installations would operate on the same folder overwriting each other causing signature verification to fail for both.

Closes #425