### PR TITLE
support installation of newer Zig version with new artifact file name

### DIFF
--- a/src/zigSetup.ts
+++ b/src/zigSetup.ts
@@ -12,6 +12,8 @@ import {
     ZigVersion,
     asyncDebounce,
     getHostZigName,
+    getZigArchName,
+    getZigOSName,
     resolveExePathAndVersion,
     workspaceConfigUpdateNoThrow,
 } from "./zigUtil";
@@ -644,7 +646,21 @@ export async function setupZig(context: vscode.ExtensionContext) {
             release: vscode.Uri.parse("https://ziglang.org/download"),
             nightly: vscode.Uri.parse("https://ziglang.org/builds"),
         },
+        getArtifactName(version) {
+            const fileExtension = process.platform === "win32" ? "zip" : "tar.xz";
+            if (
+                (version.prerelease.length === 0 && semver.gte(version, "0.14.1")) ||
+                semver.gte(version, "0.15.0-dev.631+9a3540d61")
+            ) {
+                return `zig-${getZigArchName()}-${getZigOSName()}-${version.raw}.${fileExtension}`;
+            } else {
+                return `zig-${getZigOSName()}-${getZigArchName()}-${version.raw}.${fileExtension}`;
+            }
+        },
     };
+
+    // Remove after some time has passed from the prefix change.
+    await versionManager.convertOldInstallPrefixes(versionManagerConfig);
 
     zigProvider = new ZigProvider();
 

--- a/src/zigSetup.ts
+++ b/src/zigSetup.ts
@@ -681,6 +681,11 @@ export async function setupZig(context: vscode.ExtensionContext) {
         }
     }, 200);
 
+    if (!vscode.workspace.getConfiguration("zig").get<string>("path")) {
+        await installZig(context);
+    }
+    await updateStatus(context);
+
     const onDidChangeActiveTextEditor = (editor: vscode.TextEditor | undefined) => {
         if (editor?.document.languageId === "zig") {
             statusItem.show();
@@ -722,6 +727,4 @@ export async function setupZig(context: vscode.ExtensionContext) {
         watcher2.onDidDelete(refreshZigInstallation),
         watcher2,
     );
-
-    await refreshZigInstallation();
 }

--- a/src/zls.ts
+++ b/src/zls.ts
@@ -15,7 +15,14 @@ import semver from "semver";
 
 import * as minisign from "./minisign";
 import * as versionManager from "./versionManager";
-import { getHostZigName, handleConfigOption, resolveExePathAndVersion, workspaceConfigUpdateNoThrow } from "./zigUtil";
+import {
+    getHostZigName,
+    getZigArchName,
+    getZigOSName,
+    handleConfigOption,
+    resolveExePathAndVersion,
+    workspaceConfigUpdateNoThrow,
+} from "./zigUtil";
 import { zigProvider } from "./zigSetup";
 
 const ZIG_MODE = [
@@ -436,7 +443,14 @@ export async function activate(context: vscode.ExtensionContext) {
             release: vscode.Uri.parse("https://builds.zigtools.org"),
             nightly: vscode.Uri.parse("https://builds.zigtools.org"),
         },
+        getArtifactName(version) {
+            const fileExtension = process.platform === "win32" ? "zip" : "tar.xz";
+            return `zls-${getZigOSName()}-${getZigArchName()}-${version.raw}.${fileExtension}`;
+        },
     };
+
+    // Remove after some time has passed from the prefix change.
+    await versionManager.convertOldInstallPrefixes(versionManagerConfig);
 
     outputChannel = vscode.window.createOutputChannel("ZLS language server", { log: true });
     statusItem = vscode.languages.createLanguageStatusItem("zig.zls.status", ZIG_MODE);


### PR DESCRIPTION
The first commit is an alternative to #429. The additional commits mostly focus on improve the error handling when something in the version manager has gone wrong.
