### PR TITLE
update vscode-languageclient to 10.0.0-next.15

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "libsodium-wrappers": "^0.7.15",
         "lodash-es": "^4.17.21",
         "semver": "^7.5.2",
-        "vscode-languageclient": "8.0.2-next.5",
+        "vscode-languageclient": "10.0.0-next.15",
         "which": "^3.0.0"
       },
       "devDependencies": {
@@ -1140,6 +1140,7 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -1339,7 +1340,8 @@
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -2510,6 +2512,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -2622,6 +2625,7 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
       "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -3075,12 +3079,10 @@
       "dev": true
     },
     "node_modules/semver": {
-      "version": "7.6.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
-      "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -3431,39 +3433,67 @@
       "optional": true
     },
     "node_modules/vscode-jsonrpc": {
-      "version": "8.0.2-next.1",
-      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.0.2-next.1.tgz",
-      "integrity": "sha512-sbbvGSWja7NVBLHPGawtgezc8DHYJaP4qfr/AaJiyDapWcSFtHyPtm18+LnYMLTmB7bhOUW/lf5PeeuLpP6bKA==",
+      "version": "9.0.0-next.8",
+      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-9.0.0-next.8.tgz",
+      "integrity": "sha512-pN6L5eiNBvUpNFBJvudaZ83klir0T/wLFCDpYhpOEsKXyhsWyYsNMzoG7BK6zJoZLHGSSsaTJDjCcPwnLgUyPQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/vscode-languageclient": {
-      "version": "8.0.2-next.5",
-      "resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-8.0.2-next.5.tgz",
-      "integrity": "sha512-g87RJLHz0XlRyk6DOTbAk4JHcj8CKggXy4JiFL7OlhETkcYzTOR8d+Qdb4GqZr37PDs1Cl21omtTNK5LyR/RQg==",
+      "version": "10.0.0-next.15",
+      "resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-10.0.0-next.15.tgz",
+      "integrity": "sha512-BC4bOb5550V+G9BbI0w185H9j0PN/RR08HRWkLL2SCIPvqYrCs2MhVNdura0I3X/lGUHs2F81EVB6xbg0xIhFw==",
+      "license": "MIT",
       "dependencies": {
-        "minimatch": "^3.0.4",
-        "semver": "^7.3.5",
-        "vscode-languageserver-protocol": "3.17.2-next.6"
+        "minimatch": "^10.0.1",
+        "semver": "^7.7.1",
+        "vscode-languageserver-protocol": "3.17.6-next.13"
       },
       "engines": {
-        "vscode": "^1.67.0"
+        "vscode": "^1.91.0"
+      }
+    },
+    "node_modules/vscode-languageclient/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/vscode-languageclient/node_modules/minimatch": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.0.1.tgz",
+      "integrity": "sha512-ethXTt3SGGR+95gudmqJ1eNhRO7eGEGIgYA9vnPatK4/etz2MEVDno5GMCibdMTuBMyElzIlgxMna3K94XDIDQ==",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/vscode-languageserver-protocol": {
-      "version": "3.17.2-next.6",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.2-next.6.tgz",
-      "integrity": "sha512-WtsebNOOkWyNn4oFYoAMPC8Q/ZDoJ/K7Ja53OzTixiitvrl/RpXZETrtzH79R8P5kqCyx6VFBPb6KQILJfkDkA==",
+      "version": "3.17.6-next.13",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.6-next.13.tgz",
+      "integrity": "sha512-IE+/j+OOqJ392KMhcexIGt9MVqcTZ4n7DVyaSp5txuC1kNUnfzxlkPzzDwo0p7hdINLCfWjbcjuW5tGYLof4Vw==",
+      "license": "MIT",
       "dependencies": {
-        "vscode-jsonrpc": "8.0.2-next.1",
-        "vscode-languageserver-types": "3.17.2-next.2"
+        "vscode-jsonrpc": "9.0.0-next.8",
+        "vscode-languageserver-types": "3.17.6-next.6"
       }
     },
     "node_modules/vscode-languageserver-types": {
-      "version": "3.17.2-next.2",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.2-next.2.tgz",
-      "integrity": "sha512-TiAkLABgqkVWdAlC3XlOfdhdjIAdVU4YntPUm9kKGbXr+MGwpVnKz2KZMNBcvG0CFx8Hi8qliL0iq+ndPB720w=="
+      "version": "3.17.6-next.6",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.6-next.6.tgz",
+      "integrity": "sha512-aiJY5/yW+xzw7KPNlwi3gQtddq/3EIn5z8X8nCgJfaiAij2R1APKePngv+MUdLdYJBVTLu+Qa0ODsT+pHgYguQ==",
+      "license": "MIT"
     },
     "node_modules/which": {
       "version": "3.0.1",
@@ -3510,7 +3540,8 @@
     "node_modules/yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
     },
     "node_modules/yauzl": {
       "version": "2.10.0",

--- a/package.json
+++ b/package.json
@@ -415,7 +415,7 @@
     "libsodium-wrappers": "^0.7.15",
     "lodash-es": "^4.17.21",
     "semver": "^7.5.2",
-    "vscode-languageclient": "8.0.2-next.5",
+    "vscode-languageclient": "10.0.0-next.15",
     "which": "^3.0.0"
   }
 }

--- a/src/zls.ts
+++ b/src/zls.ts
@@ -3,7 +3,6 @@ import vscode from "vscode";
 import {
     CancellationToken,
     ConfigurationParams,
-    DocumentSelector,
     LSPAny,
     LanguageClient,
     LanguageClientOptions,
@@ -19,14 +18,14 @@ import * as versionManager from "./versionManager";
 import { getHostZigName, handleConfigOption, resolveExePathAndVersion, workspaceConfigUpdateNoThrow } from "./zigUtil";
 import { zigProvider } from "./zigSetup";
 
-const ZIG_MODE: DocumentSelector = [
+const ZIG_MODE = [
     { language: "zig", scheme: "file" },
     { language: "zig", scheme: "untitled" },
 ];
 
 let versionManagerConfig: versionManager.Config;
 let statusItem: vscode.LanguageStatusItem;
-let outputChannel: vscode.OutputChannel;
+let outputChannel: vscode.LogOutputChannel;
 export let client: LanguageClient | null = null;
 
 export async function restartClient(context: vscode.ExtensionContext): Promise<void> {
@@ -87,7 +86,7 @@ async function startClient(zlsPath: string, zlsVersion: semver.SemVer): Promise<
     const languageClient = new LanguageClient("zig.zls", "ZLS language server", serverOptions, clientOptions);
     await languageClient.start();
     // Formatting is handled by `zigFormat.ts`
-    languageClient.getFeature("textDocument/formatting").dispose();
+    languageClient.getFeature("textDocument/formatting").clear();
     return languageClient;
 }
 
@@ -439,7 +438,7 @@ export async function activate(context: vscode.ExtensionContext) {
         },
     };
 
-    outputChannel = vscode.window.createOutputChannel("ZLS language server");
+    outputChannel = vscode.window.createOutputChannel("ZLS language server", { log: true });
     statusItem = vscode.languages.createLanguageStatusItem("zig.zls.status", ZIG_MODE);
     statusItem.name = "ZLS";
     updateStatusItem(null);


### PR DESCRIPTION
One notable improvement is the new support for VS Code's [LogOutputChannel](https://github.com/microsoft/vscode-languageserver-node/issues/1116) which greatly improves how the ZLS logs are rendered.

Before:

![vscode-output-channel-before](https://github.com/user-attachments/assets/40099666-cd57-4bf1-880a-ae37965036c3)

After:

![vscode-output-channel-after](https://github.com/user-attachments/assets/0638dd94-0bce-4f58-b330-845d32d102f2)

The new output not only looks better but is also more customizable with the log filter in the top right.