### PR TITLE
fix: Stop overwriting user-configured paths

### DIFF
--- a/src/zigProvider.ts
+++ b/src/zigProvider.ts
@@ -44,6 +44,7 @@ export class ZigProvider {
         const zigConfig = vscode.workspace.getConfiguration("zig");
         if (!zigPath) {
             await workspaceConfigUpdateNoThrow(zigConfig, "path", undefined, true);
+            this.set(null);
             return;
         }
         const newValue = this.resolveZigPathConfigOption(zigPath);
@@ -59,16 +60,9 @@ export class ZigProvider {
         const result = resolveExePathAndVersion(zigPath, "version");
         if ("message" in result) {
             vscode.window
-                .showErrorMessage(`Unexpected 'zig.path': ${result.message}`, "install Zig", "open settings")
+                .showErrorMessage(`Unexpected 'zig.path': ${result.message}`, "open settings")
                 .then(async (response) => {
                     switch (response) {
-                        case "install Zig":
-                            await workspaceConfigUpdateNoThrow(
-                                vscode.workspace.getConfiguration("zig"),
-                                "path",
-                                undefined,
-                            );
-                            break;
                         case "open settings":
                             await vscode.commands.executeCommand("workbench.action.openSettings", "zig.path");
                             break;

--- a/src/zigSetup.ts
+++ b/src/zigSetup.ts
@@ -740,11 +740,15 @@ export async function setupZig(context: vscode.ExtensionContext) {
             }
             if (change.affectsConfiguration("zig.path")) {
                 const result = zigProvider.resolveZigPathConfigOption();
-                if (result) {
+                if (result === undefined) {
+                    // Invalid path - error already shown, do nothing
+                    return;
+                }
+                if (result === null) {
+                    void refreshZigInstallation();
+                } else {
                     zigProvider.set(result);
                     void updateStatus(context);
-                } else {
-                    void refreshZigInstallation();
                 }
             }
         }),

--- a/src/zigUtil.ts
+++ b/src/zigUtil.ts
@@ -84,12 +84,9 @@ export function resolveExePathAndVersion(
         };
     }
 
-    const exePath = which.sync(cmd, { nothrow: true });
-    if (!exePath) {
-        if (!isAbsolute) {
-            return { message: `Could not find '${cmd}' in PATH.` };
-        }
+    let exePath: string | null = null;
 
+    if (isAbsolute) {
         const stats = fs.statSync(cmd, { throwIfNoEntry: false });
         if (!stats) {
             return {
@@ -103,9 +100,12 @@ export function resolveExePathAndVersion(
             };
         }
 
-        return {
-            message: `'${cmd}' is not an executable.`,
-        };
+        exePath = cmd;
+    } else {
+        exePath = which.sync(cmd, { nothrow: true });
+        if (!exePath) {
+            return { message: `Could not find '${cmd}' in PATH.` };
+        }
     }
 
     const version = getVersion(exePath, versionArg);

--- a/src/zls.ts
+++ b/src/zls.ts
@@ -119,14 +119,9 @@ async function getZLSPath(context: vscode.ExtensionContext): Promise<{ exe: stri
         const result = resolveExePathAndVersion(zlsExePath, "--version");
         if ("message" in result) {
             vscode.window
-                .showErrorMessage(`Unexpected 'zig.zls.path': ${result.message}`, "install ZLS", "open settings")
+                .showErrorMessage(`Unexpected 'zig.zls.path': ${result.message}`, "open settings")
                 .then(async (response) => {
                     switch (response) {
-                        case "install ZLS":
-                            const zlsConfig = vscode.workspace.getConfiguration("zig.zls");
-                            await workspaceConfigUpdateNoThrow(zlsConfig, "enabled", "on", true);
-                            await workspaceConfigUpdateNoThrow(zlsConfig, "path", undefined);
-                            break;
                         case "open settings":
                             await vscode.commands.executeCommand("workbench.action.openSettings", "zig.zls.path");
                             break;


### PR DESCRIPTION
## Problem

The extension forcibly overwrites user-configured `zig.path` and `zig.zls.path` settings in `settings.json`.

This extension was implemented with the assumption that "users don't need to configure paths because `zig` / `zls` can be dynamically resolved from PATH". However, this behavior can impose limitations on users.

### Example: Compatibility issues with version management tools

Version management tools like mise and asdf add shim paths to the PATH environment variable.
As a result:

- Shim paths are used instead of actual binary paths
- VSCode cannot correctly resolve `zig` / `zls`
- Even when users configure correct binary paths, they get overwritten

This problem wouldn't occur if user settings were respected.

## Solution

Modified the flow as follows:

1. When user settings exist and are valid
   → Use those settings with priority

2. When user settings exist but are invalid
   → Show error and prompt to fix settings (without overwriting)

3. When user settings don't exist
   → Dynamically resolve from PATH as before

## Changes

- Removed automatic overwriting of `zig.path`/`zig.zls.path` (updating to `undefined`)
- Removed "install Zig/ZLS" options from error dialogs that overwrite settings
- Added logic to prioritize existing settings in `installZig` function

## Result

- User-configured paths are preserved
- Users of version management tools can build stable development environments
- Extension behavior becomes predictable

## Test

 I've tested these changes by building and installing the extension locally.

## Related Issues

- [#424](https://github.com/ziglang/vscode-zig/issues/424) - Path resolution issues due to settings being overwritten