### PR TITLE
address various issues with the ZLS config middleware

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "0.6.11",
       "license": "MIT",
       "dependencies": {
-        "camelcase": "^7.0.1",
         "libsodium-wrappers": "^0.7.15",
         "lodash-es": "^4.17.21",
         "semver": "^7.5.2",
@@ -1222,17 +1221,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/camelcase": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-7.0.1.tgz",
-      "integrity": "sha512-xlx1yCK2Oc1APsPXDL2LdlNP6+uu8OCDdhOBSVT279M/S+y75O30C2VuD8T2ogdePBBl7PfPF4504tnLgX3zfw==",
-      "engines": {
-        "node": ">=14.16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/chalk": {

--- a/package.json
+++ b/package.json
@@ -412,7 +412,6 @@
     "typescript-eslint": "^8.0.0"
   },
   "dependencies": {
-    "camelcase": "^7.0.1",
     "libsodium-wrappers": "^0.7.15",
     "lodash-es": "^4.17.21",
     "semver": "^7.5.2",

--- a/src/zigDiagnosticsProvider.ts
+++ b/src/zigDiagnosticsProvider.ts
@@ -160,7 +160,7 @@ export default class ZigDiagnosticsProvider {
                 if (!buildFilePath) break;
                 processArg.push("--build-file");
                 try {
-                    processArg.push(path.resolve(handleConfigOption(buildFilePath)));
+                    processArg.push(path.resolve(handleConfigOption(buildFilePath, workspaceFolder)));
                 } catch {
                     //
                 }

--- a/src/zigUtil.ts
+++ b/src/zigUtil.ts
@@ -14,14 +14,20 @@ import which from "which";
  * Replace any references to predefined variables in config string.
  * https://code.visualstudio.com/docs/editor/variables-reference#_predefined-variables
  */
-export function handleConfigOption(input: string): string {
+export function handleConfigOption(input: string, workspaceFolder: vscode.WorkspaceFolder | "none" | "guess"): string {
     if (input.includes("${userHome}")) {
         input = input.replaceAll("${userHome}", os.homedir());
     }
 
-    if (vscode.workspace.workspaceFolders && vscode.workspace.workspaceFolders.length > 0) {
-        input = input.replaceAll("${workspaceFolder}", vscode.workspace.workspaceFolders[0].uri.fsPath);
-        input = input.replaceAll("${workspaceFolderBasename}", vscode.workspace.workspaceFolders[0].name);
+    if (workspaceFolder === "guess") {
+        workspaceFolder = vscode.workspace.workspaceFolders?.length ? vscode.workspace.workspaceFolders[0] : "none";
+    }
+
+    if (workspaceFolder !== "none") {
+        input = input.replaceAll("${workspaceFolder}", workspaceFolder.uri.fsPath);
+        input = input.replaceAll("${workspaceFolderBasename}", workspaceFolder.name);
+    } else {
+        // This may end up reporting a confusing error message.
     }
 
     const document = vscode.window.activeTextEditor?.document;
@@ -68,7 +74,7 @@ export function resolveExePathAndVersion(
     assert(cmd.length);
 
     // allow passing predefined variables
-    cmd = handleConfigOption(cmd);
+    cmd = handleConfigOption(cmd, "guess");
 
     if (cmd.startsWith("~")) {
         cmd = path.join(os.homedir(), cmd.substring(1));

--- a/src/zls.ts
+++ b/src/zls.ts
@@ -170,6 +170,7 @@ function configurationMiddleware(params: ConfigurationParams): LSPAny[] | Respon
 
         const scopeUri = param.scopeUri ? client?.protocol2CodeConverter.asUri(param.scopeUri) : undefined;
         const configuration = vscode.workspace.getConfiguration("zig", scopeUri);
+        const workspaceFolder = scopeUri ? vscode.workspace.getWorkspaceFolder(scopeUri) : undefined;
 
         const updateConfigOption = (section: string, value: unknown) => {
             if (section === "zls.zigExePath") {
@@ -178,7 +179,7 @@ function configurationMiddleware(params: ConfigurationParams): LSPAny[] | Respon
 
             if (typeof value === "string") {
                 // Make sure that `""` gets converted to `undefined` and resolve predefined values
-                value = value ? handleConfigOption(value) : undefined;
+                value = value ? handleConfigOption(value, workspaceFolder ?? "guess") : undefined;
             } else if (typeof value === "object" && value !== null && !Array.isArray(value)) {
                 // Recursively update the config options
                 const newValue: Record<string, unknown> = {};

--- a/src/zls.ts
+++ b/src/zls.ts
@@ -8,9 +8,8 @@ import {
     ResponseError,
     ServerOptions,
 } from "vscode-languageclient/node";
-import camelCase from "camelcase";
+import { camelCase, snakeCase } from "lodash-es";
 import semver from "semver";
-import { snakeCase } from "lodash-es";
 
 import * as minisign from "./minisign";
 import * as versionManager from "./versionManager";


### PR DESCRIPTION
I am currently planning to change how ZLS requests config options using the `workspace/Configuration` request which has led me to identify some issues with the extension's handling of this request. The extension currently assumes that ZLS will request individual config options instead using a [ConfigurationItem](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#configurationItem) with `section == "zls"` to request all config options as a single JSON object. With these changes, the extension should be able to handle both strategies.

This also has the benefit that it can make supporting config options that are not specified in the `package.json` trivial without the need for `zig.zls.additionalOptions` (#182). I plan to open a follow up issue about this.