### PR TITLE
Make debug adapter configurable

### DIFF
--- a/package.json
+++ b/package.json
@@ -150,6 +150,12 @@
           ],
           "description": "Arguments to pass to 'zig' for running tests. Supported variables: ${filter}, ${path}."
         },
+        "zig.zls.debugAdapter": {
+          "scope": "resource",
+          "type": "string",
+          "default": "lldb",
+          "description": "The debug adapter command to run when starting a debug session"
+        },
         "zig.zls.debugLog": {
           "scope": "resource",
           "type": "boolean",

--- a/src/zigMainCodeLens.ts
+++ b/src/zigMainCodeLens.ts
@@ -79,8 +79,11 @@ async function zigDebug() {
         }
         if (!binaryPath) return;
 
+        const config = vscode.workspace.getConfiguration("zig.zls");
+        const debugAdapter = config.get<string>("debugAdapter", "lldb");
+
         const debugConfig: vscode.DebugConfiguration = {
-            type: "lldb",
+            type: debugAdapter,
             name: `Debug Zig`,
             request: "launch",
             program: binaryPath,

--- a/src/zigTestRunnerProvider.ts
+++ b/src/zigTestRunnerProvider.ts
@@ -195,9 +195,13 @@ export default class ZigTestRunnerProvider {
         if (testItem.uri === undefined) {
             throw new Error("Unable to determine file location");
         }
+        
+        const config = vscode.workspace.getConfiguration("zig.zls");
+        const debugAdapter = config.get<string>("debugAdapter", "lldb");
+       
         const testBinaryPath = await this.buildTestBinary(run, testItem.uri.fsPath, getTestDesc(testItem));
         const debugConfig: vscode.DebugConfiguration = {
-            type: "lldb",
+            type: debugAdapter,
             name: `Debug ${testItem.label}`,
             request: "launch",
             program: testBinaryPath,


### PR DESCRIPTION
Add a config option to chose a debug adapter other than lldb (codelldb), for example lldb-dap
Wasn't sure on the best namespace for the setting so I settled on zig.zls.debugAdapter however this could easily be changed

Closes #264