### PR TITLE
Add configuration `debugTestArgs`

### DIFF
--- a/package.json
+++ b/package.json
@@ -150,6 +150,21 @@
           ],
           "description": "Arguments to pass to 'zig' for running tests. Supported variables: ${filter}, ${path}."
         },
+        "zig.debugTestArgs": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": [
+            "test",
+            "${path}",
+            "--test-filter",
+            "${filter}",
+            "--test-no-exec",
+            "-femit-bin=${binaryPath}"
+          ],
+          "description": "Arguments to pass to 'zig' for debugging tests. Supported variables: ${filter}, ${path}, ${binaryPath}."
+        },
         "zig.debugAdapter": {
           "scope": "resource",
           "type": "string",


### PR DESCRIPTION
This adds the `debugTestArgs` option, which allows users to override the arguments used to build a test binary, similar to `testArgs`. It also changes the working directory to the workspace folder to allow running `zig build`.

Note that using the absolute `binaryPath` variable from `build.zig` is currently cumbersome, as it doesn’t integrate well with the way install paths are just relative directories within the install directory.

Supersedes #445
Closes #443