### PR TITLE
disable ziglang/zig#21905 workaround when used with recent Zig version

### DIFF
--- a/src/zigSetup.ts
+++ b/src/zigSetup.ts
@@ -621,6 +621,11 @@ export async function setupZig(context: vscode.ExtensionContext) {
                 if (document.languageId !== "zig") return;
                 if (document.uri.scheme !== "file") return;
 
+                const zigVersion = zigProvider.getZigVersion();
+                if (!zigVersion) return;
+
+                if (semver.gte(zigVersion, "0.15.0-dev.1372+abf179533")) return;
+
                 const fsPath = document.uri.fsPath;
                 try {
                     await fs.copyFile(fsPath, fsPath + ".tmp", fs.constants.COPYFILE_EXCL);


### PR DESCRIPTION
This issue has been fixed in ziglang/zig#24649. The workaround can be removed completely when it's safe to assume that the majority of projects and users have updated to Zig 0.15.