### PR TITLE
Make debug test binary name predictable and add some guidance on how to use the options with build scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -129,7 +129,7 @@
             "${filter}",
             "${path}"
           ],
-          "description": "Arguments to pass to 'zig' for running tests. Supported variables: ${filter}, ${path}."
+          "description": "Arguments to pass to 'zig' for running tests. Supported variables: ${filter}, ${path}.\n\nTo use test filter with a build script define a custom option to pass it to: `-Dtest-filter=${filter}`."
         },
         "zig.debugTestArgs": {
           "type": "array",
@@ -144,7 +144,7 @@
             "--test-no-exec",
             "-femit-bin=${binaryPath}"
           ],
-          "description": "Arguments to pass to 'zig' for debugging tests. Supported variables: ${filter}, ${path}, ${binaryPath}."
+          "description": "Arguments to pass to 'zig' for debugging tests. Supported variables: ${filter}, ${path}, ${binaryPath}.\n\nTo debug a test with a build script add a step that installs the test binary at `zig-out/bin/debug-unit-tests`:\n```zig\nb.step(\"debug-test-unit\", \"Debug unit tests\").dependOn(&b.addInstallArtifact(unit_tests, .{ .dest_sub_path = \"debug-unit-tests\" }).step);\n```"
         },
         "zig.debugAdapter": {
           "scope": "resource",

--- a/src/zigTestRunnerProvider.ts
+++ b/src/zigTestRunnerProvider.ts
@@ -283,9 +283,8 @@ export default class ZigTestRunnerProvider {
         }
 
         const wsFolder = getWorkspaceFolder(testFilePath)?.uri.fsPath ?? path.dirname(testFilePath);
-        const outputDir = path.join(wsFolder, "zig-out", "tmp-debug-build", "bin");
-        const binaryName = `test-${path.basename(testFilePath, ".zig")}`;
-        const binaryPath = path.join(outputDir, binaryName);
+        const outputDir = path.join(wsFolder, "zig-out", "bin");
+        const binaryPath = path.join(outputDir, "debug-unit-tests");
         await vscode.workspace.fs.createDirectory(vscode.Uri.file(outputDir));
 
         const debugTestArgsConf = config.get<string[]>("debugTestArgs") ?? [];


### PR DESCRIPTION
The documentation is supposed to help with issues like https://github.com/ziglang/vscode-zig/issues/443#issuecomment-3478476992 but the description of the settings doesn't feel like the best place to do it and I'm not sure how much better a walkthrough (#407) would be.