### PR TITLE
update source query and avoid percent encoding urls when downloading from mirrors

### DIFF
--- a/src/versionManager.ts
+++ b/src/versionManager.ts
@@ -157,12 +157,18 @@ async function installFromMirror(
         abortController.abort();
     });
 
+    /**
+     * https://ziglang.org/download/community-mirrors/ encouraged the addition
+     * of a `source` query parameter to specify what is making this request.
+     * This extension is published as `ziglang.vscode-zig` so we use base it off that.
+     */
+    const sourceQuery = "ziglang-vscode-zig";
+
     const artifactUrl = new URL(fileName, mirrorUrl.toString());
-    /** https://github.com/mlugg/setup-zig adds a `?source=github-actions` query parameter so we add our own.  */
-    artifactUrl.searchParams.set("source", "vscode-zig");
+    artifactUrl.searchParams.set("source", sourceQuery);
 
     const artifactMinisignUrl = new URL(`${fileName}.minisig`, mirrorUrl.toString());
-    artifactMinisignUrl.searchParams.set("source", "vscode-zig");
+    artifactMinisignUrl.searchParams.set("source", sourceQuery);
 
     const signatureResponse = await fetch(artifactMinisignUrl, {
         signal: abortController.signal,


### PR DESCRIPTION
The `toString` function on `vscode.Uri` will aggressively apply percent encoding even if unnecessary for some character+component cases.

This affects the `+` in the filename of nightly versions and the `=` in the query parameter. While it is valid to percent encode even if unnecessary, this can still lead to confusion about whether the url  is valid if the reader is unfamiliar with the rules around percent encoding.

There is no downside to just using `URL` instead of `vscode.Uri` so that we get more readable urls. This can be especially helpful if the encoded url happens to be shown to the extension user through the error message of an exception as an example.

closes #468

I also updated `source` query parameter from `vscode-zig` to `github-ziglang-vscode-zig` to be similar to what mlugg/setup-zig does.