### PR TITLE
fix incorrect URL path resolution when downloading artifacts

### DIFF
--- a/src/versionManager.ts
+++ b/src/versionManager.ts
@@ -164,10 +164,10 @@ async function installFromMirror(
      */
     const sourceQuery = "ziglang-vscode-zig";
 
-    const artifactUrl = new URL(fileName, mirrorUrl.toString());
+    const artifactUrl = new URL(fileName, mirrorUrl.toString() + (mirrorUrl.path.endsWith("/") ? "" : "/"));
     artifactUrl.searchParams.set("source", sourceQuery);
 
-    const artifactMinisignUrl = new URL(`${fileName}.minisig`, mirrorUrl.toString());
+    const artifactMinisignUrl = new URL(`${artifactUrl.toString()}.minisig`);
     artifactMinisignUrl.searchParams.set("source", sourceQuery);
 
     const signatureResponse = await fetch(artifactMinisignUrl, {


### PR DESCRIPTION
The URL constructor removes the last path component unless it ends with a trailing slash.

See https://github.com/ziglang/vscode-zig/pull/469#issuecomment-3541412148