### PR TITLE
fix incorrect URL to `.minisig` file

### DIFF
--- a/src/versionManager.ts
+++ b/src/versionManager.ts
@@ -157,18 +157,16 @@ async function installFromMirror(
         abortController.abort();
     });
 
+    const artifactUrl = new URL(fileName, mirrorUrl.toString() + (mirrorUrl.path.endsWith("/") ? "" : "/"));
+    const artifactMinisignUrl = new URL(`${artifactUrl.toString()}.minisig`);
+
     /**
      * https://ziglang.org/download/community-mirrors/ encouraged the addition
      * of a `source` query parameter to specify what is making this request.
      * This extension is published as `ziglang.vscode-zig` so we use base it off that.
      */
-    const sourceQuery = "ziglang-vscode-zig";
-
-    const artifactUrl = new URL(fileName, mirrorUrl.toString() + (mirrorUrl.path.endsWith("/") ? "" : "/"));
-    artifactUrl.searchParams.set("source", sourceQuery);
-
-    const artifactMinisignUrl = new URL(`${artifactUrl.toString()}.minisig`);
-    artifactMinisignUrl.searchParams.set("source", sourceQuery);
+    artifactUrl.searchParams.set("source", "ziglang-vscode-zig");
+    artifactMinisignUrl.searchParams.set("source", "ziglang-vscode-zig");
 
     const signatureResponse = await fetch(artifactMinisignUrl, {
         signal: abortController.signal,


### PR DESCRIPTION
I have unfortunately managed to sneak in another regression while trying to fix the previous one. The `artifactMinisignUrl` will always be incorrect because it appends `.minisig` after appending `?source=ziglang-vscode-zig` which would result in the following URL:
```
https://mirror.org/zig/filename.zip?source=ziglang-vscode-zig.minisig
```
so it downloads the tarball/zip again instead of the minisig and then silently fails during verification. This will then repeat for every mirror until utimately failing with ziglang.org. During testing I always aborted the installation early before reaching minisign verification so I didn't notice my mistake. Sorry about that.

